### PR TITLE
multichar line sep on server socket

### DIFF
--- a/S32-io/IO-Socket-INET.t
+++ b/S32-io/IO-Socket-INET.t
@@ -1,7 +1,7 @@
 use v6;
 use Test;
 
-plan 47;
+plan 49;
 
 {
     #?rakudo.jvm emit skip_rest('rakudo.jvm systemic failures/OOM error');
@@ -205,6 +205,22 @@ if $*OS eq any <linux Linux darwin solaris MSWin32>, 'Mac OS X' { # please add m
     nok $elapsed > $toolong, "finished in time #22";
     is $expected[$i++], 4, "{elapsed} total amount ";
     nok $elapsed > $toolong, "finished in time #23";
+
+    # test 10 verifies multichar line sep on server socket
+    if $is-win {
+        $received = qqx{$runner t\\spec\\S32-io\\IO-Socket-INET.bat 10 $port};
+    } else {
+        $received = qqx{$runner sh t/spec/S32-io/IO-Socket-INET.sh 10 $port};
+    }
+    constant CRLF = "\x0D\x0A";
+    constant LF = "\x0A";
+    # FAILS ON MOAR, JVM AND PARROT
+    $expected = "Some stuff" ~ CRLF ~ "Got more stuff";
+    # FAILS ON MOAR ONLY
+    # $expected = "Some stuff" ~ CRLF ~ "Got more stuff" ~ LF;
+    is $received, $expected, "{elapsed} line sep on server socket";
+    nok $elapsed > $toolong, "finished in time #24";
+
 }
 else {
     skip "OS '$*OS' shell support not confirmed", 1;

--- a/S32-io/IO-Socket-INET.t
+++ b/S32-io/IO-Socket-INET.t
@@ -214,10 +214,9 @@ if $*OS eq any <linux Linux darwin solaris MSWin32>, 'Mac OS X' { # please add m
     }
     constant CRLF = "\x0D\x0A";
     constant LF = "\x0A";
-    # FAILS ON MOAR, JVM AND PARROT
-    $expected = "Some stuff" ~ CRLF ~ "Got more stuff";
     # FAILS ON MOAR ONLY
-    # $expected = "Some stuff" ~ CRLF ~ "Got more stuff" ~ LF;
+    # Additional Line Feed at the end comes from say
+    $expected = "Some stuff" ~ CRLF ~ "Got more stuff" ~ LF;
     is $received, $expected, "{elapsed} line sep on server socket";
     nok $elapsed > $toolong, "finished in time #24";
 


### PR DESCRIPTION
This test verifies that the sockets can operate on
multichar line seperators for calls to get.

This should already have been verified by test 5.
Somehow that test passes when this one does not.
Test 5 seems to the on the client socket.

jnthn mentioned that MOAR does not like multichar
line sepearators. But the problem seems to persist
for Parrot and JVM backend in a slightly different
manner.

I only tested this patch on Linux.
