### PR TITLE
Suggested tests for signature mismatch on .?

### DIFF
--- a/S12-methods/calling_sets.t
+++ b/S12-methods/calling_sets.t
@@ -173,4 +173,26 @@ is MMT2.new.?foo("lol"), 42, '.? when initial multi does not match will find nex
 
 throws-like '1.*WHAT', X::AdHoc, '.WHAT is a macro and cannoted be .*ed';
 
+class H {
+    method foo(H:D:) { 'meh' }
+    method bar($x) { 10 }
+
+    multi method baz(H:D:) { 'ok' }
+    multi method baz($x) { 42 }
+}
+
+{
+    my H $h;
+
+    # signature mismatch causes exception even on .?
+    dies-ok { $h.?foo }, 'Invocant requires an instance of type H, but a type object was passed.  Did you forget a .new?';
+    dies-ok { $h.?bar }, 'Too few positionals passed; expected 2 arguments but got 1';
+
+    # signature mismatch on .? does not except on multi
+    lives-ok { $h.?baz };
+    $h .= new;
+    lives-ok { $h.?baz };
+}
+
+
 # vim: ft=perl6


### PR DESCRIPTION
Some relevant discussion here:

http://irclog.perlgeek.de/perl6/2015-10-22#i_11420122

How should a .? dispatch be handled when the method exists, but the signature
does not match? The current de facto implementation takes a very literal
interpretation of S12 and checks to see if the method exists. If it does, then
it will fail with an exception related to signature mismatch. If it does not,
then no operation occurs and Nil is returned.

I suggest that for the sake of doing something like this:

```
$object.?one.?two.?three;
```

that it makes more sense to take the signature into account. That is, if method
"one" returns an object of type One with a two method defined like this:

```
class One {
    method two(One:D:) returns Two { ... }
}
```

and Two is similarly defined, should .? dispatch continue or fail? I understand
(from coworkers) that Swift and C# have .? operators that would succeed. In the
case of C# (which I know very little about) can just short-circuit on the first
null it encounters. Perl 6 can actually provide type context for it's null
values though and might provide a valid method to dispatch.

These new tests provide a spec for changing the de facto implementation in
rakudo which currently fails for signature mismatch in all cases. I suggest that
this is incorrect, but I think there are at least two ways to correct the issue.
I have written the tests with option 2 in mind as I think it makes the most
sense, but I think option 1 is fine. The unspoken other option is to leave the
current de facto implementation alone (though, we ought to have tests for it
too), but I'd like to at least have a reasonable explanation for why the current
way is a good way (even if I disagree).
1. We allow .? dispatch to succeed with a Nil in any case where the method
   signature of the call does not match the method signature of the object.
2. We allow .? dispatch to succeed with a Nil only in cases where the method
   signature mismatches on a multi-method. Any regular method would still fail
   with an error on the signature.

I prefer Option 2 myself because it makes more sense to me in that case that
this method may have multiple signatures and .? is saying in such a case: match
one if available or nothing if not available. I think failing makes sense
without multi because the class is sort of saying "this is all there is and
anything else is wrong."

I have not added them yet, but the .\* cases ought to be added as well.
