### PR TITLE
Putting a few things in order

### DIFF
--- a/S04-phasers/interpolate.t
+++ b/S04-phasers/interpolate.t
@@ -4,7 +4,7 @@ use v6;
 
 use Test;
 
-plan 6;
+plan 5;
 
 # [TODO] add tests for ENTER/LEAVE/KEEP/UNDO/PRE/POST/etc
 
@@ -21,22 +21,20 @@ plan 6;
 my $hist;
 
 END {
-    is $hist, 'BCISE', 'interpolated END {...} executed';
+    is $hist, 'BCIE', 'interpolated END {...} executed';
 }
 
-nok "{ END { $hist ~= 'E' } }".defined,
+# END phaser doesn't have a return value.
+nok "{ END { $hist ~= 'E' } // "" }",
     'END {...} not yet executed';
 
-is "{ START { $hist ~= 'S' } }", "BCIS",
-    'START {...} fired at run-time, entry time of the mainline code';
-
-is "{ INIT { $hist ~= 'I' } }", 'BCI',
+is "{ INIT { $hist ~= 'I'; $hist<> } }", 'BCI',
     'INIT {...} fired at the beginning of runtime';
 
-is "{ CHECK { $hist ~= 'C' } }", "BC",
+is "{ CHECK { $hist ~= 'C'; $hist<> } }", "BC",
     'CHECK {...} fired at compile-time, ALAP';
 
-is "{ BEGIN { $hist ~= 'B' } }", "B",
+is "{ BEGIN { $hist ~= 'B'; $hist<> } }", "B",
     'BEGIN {...} fired at compile-time, ASAP';
 
 # vim: expandtab shiftwidth=4

--- a/S04-statements/lazy.t
+++ b/S04-statements/lazy.t
@@ -7,10 +7,12 @@ use Test;
 plan 10;
 
 # https://github.com/Raku/old-issue-tracker/issues/3885
+#?rakudo eval "lazy in not there yet"
 {
   my $was_in_lazy;
+  my $var;
 
-  my $var := lazy { $was_in_lazy++; 42 };
+  $var := lazy { $was_in_lazy++; 42 };
 
   #?rakudo todo 'lazy NYI, currently works like "do"; RT #124571'
   ok !$was_in_lazy,     'lazy block wasn\'t yet executed (1)';
@@ -24,6 +26,7 @@ plan 10;
 
 # https://github.com/Raku/old-issue-tracker/issues/3885
 # dies-ok/lives-ok tests:
+#?rakudo eval "lazy in not there yet"
 {
   my $was_in_lazy;
   my $lazy := lazy { $was_in_lazy++; 42 };
@@ -33,6 +36,7 @@ plan 10;
 }
 
 # https://github.com/Raku/old-issue-tracker/issues/3885
+#?rakudo eval "lazy in not there yet"
 {
   my $was_in_lazy;
   my $lazy := lazy { $was_in_lazy++; 42 };
@@ -42,6 +46,7 @@ plan 10;
   ok !$was_in_lazy, "rebinding var bound to a lazy does not evaluate lazy block";
 }
 
+#?rakudo todo "lazy in not there yet"
 {
   throws-like '(lazy { 43 }) = 23 ', X::Assignment::RO,
     "assigning to a lazily computed value does not work";

--- a/S04-statements/leave.t
+++ b/S04-statements/leave.t
@@ -7,198 +7,207 @@ use Test;
 
 plan 23;
 
-{
-  my $bare = { leave 42; 23 };
+# Because I'm unsure if method `leave` would ever be implemented I make two separate fudges here. The first one will
+# trigger a "TODO passed" when the keyword will work. The remaining tests are to be reconsidered when time comes.
 
-  is $bare(), 42, 'basic leave() works';
+#?rakudo eval "leave is not implemented yet"
+{
+    {
+      my $bare = { leave 42; 23 };
+
+      is $bare(), 42, 'basic leave() works';
+    }
 }
 
+#?rakudo eval "leave is not implemented yet"
 {
-  my $bare = { &?BLOCK.leave(42); 23 };
+    {
+      my $bare = { &?BLOCK.leave(42); 23 };
 
-  is $bare(), 42, 'basic leave() is equivalent to &?BLOCK.leave()';
-}
+      is $bare(), 42, 'basic leave() is equivalent to &?BLOCK.leave()';
+    }
 
-{
-  my $bare = { &?BLOCK.leave: 42; 23 };
+    {
+      my $bare = { &?BLOCK.leave: 42; 23 };
 
-  is $bare(), 42, 'basic method leave works as colon listop';
-}
+      is $bare(), 42, 'basic method leave works as colon listop';
+    }
 
-{
-  my $bare = { leave &?BLOCK: 42; 23 };
+    {
+      my $bare = { leave &?BLOCK: 42; 23 };
 
-  is $bare(), 42, 'basic method leave works with indirect object';
-}
+      is $bare(), 42, 'basic method leave works with indirect object';
+    }
 
-{
-  my @bare = [41, do { leave; 23 }, 43 ];
+    {
+      my @bare = [41, do { leave; 23 }, 43 ];
 
-  is @bare, [41,43], 'basic leave returns null list in list context';
-}
+      is @bare, [41,43], 'basic leave returns null list in list context';
+    }
 
-{
-  my @bare = [41, do { 21 + leave() + 23 }, 43 ];
+    {
+      my @bare = [41, do { 21 + leave() + 23 }, 43 ];
 
-  is @bare, [41,43], 'basic leave() returns null list in list context';
-}
+      is @bare, [41,43], 'basic leave() returns null list in list context';
+    }
 
-{
-  my @bare = [41, do { &?BLOCK.leave; 23 }, 43 ];
+    {
+      my @bare = [41, do { &?BLOCK.leave; 23 }, 43 ];
 
-  is @bare, [41,43], 'basic &?BLOCK.leave returns null list in list context';
-}
+      is @bare, [41,43], 'basic &?BLOCK.leave returns null list in list context';
+    }
 
-{
-  my @bare = [41, do { 21 + &?BLOCK.leave() + 23 }, 43 ];
+    {
+      my @bare = [41, do { 21 + &?BLOCK.leave() + 23 }, 43 ];
 
-  is @bare, [41,43], 'basic &?BLOCK.leave() returns null list in list context';
-}
+      is @bare, [41,43], 'basic &?BLOCK.leave() returns null list in list context';
+    }
 
-{
-  my @bare = [41, do { leave &?BLOCK: ; 23 }, 43 ];
+    {
+      my @bare = [41, do { leave &?BLOCK: ; 23 }, 43 ];
 
-  is @bare, [41,43], 'basic leave &?BLOCK: returns null list in list context';
-}
+      is @bare, [41,43], 'basic leave &?BLOCK: returns null list in list context';
+    }
 
-{
-  my @bare = [41, do { 21 + (leave &?BLOCK:) + 23 }, 43 ];
+    {
+      my @bare = [41, do { 21 + (leave &?BLOCK:) + 23 }, 43 ];
 
-  is @bare, [41,43], 'basic leave &?BLOCK: returns null list in list context';
-}
+      is @bare, [41,43], 'basic leave &?BLOCK: returns null list in list context';
+    }
 
-{
-  my @bare = [41, do { leave 42, 43; 23 }, 44 ];
+    {
+      my @bare = [41, do { leave 42, 43; 23 }, 44 ];
 
-  is @bare, [41,42,43,44], 'basic leave returns valid list in list context';
-}
+      is @bare, [41,42,43,44], 'basic leave returns valid list in list context';
+    }
 
-{
-  my @bare = [41, do { 21 + leave(42, 43) + 23 }, 44 ];
+    {
+      my @bare = [41, do { 21 + leave(42, 43) + 23 }, 44 ];
 
-  is @bare, [41,42,43,44], 'basic leave() returns valid list in list context';
-}
+      is @bare, [41,42,43,44], 'basic leave() returns valid list in list context';
+    }
 
-{
-  my @bare = [41, do { 21 + &?BLOCK.leave(42,43) + 23 }, 44 ];
+    {
+      my @bare = [41, do { 21 + &?BLOCK.leave(42,43) + 23 }, 44 ];
 
-  is @bare, [41,42,43,44], 'basic &?BLOCK.leave() returns valid list in list context';
-}
+      is @bare, [41,42,43,44], 'basic &?BLOCK.leave() returns valid list in list context';
+    }
 
-{
-  my @bare = [41, do { leave &?BLOCK: 42, 43; 23 }, 44 ];
+    {
+      my @bare = [41, do { leave &?BLOCK: 42, 43; 23 }, 44 ];
 
-  is @bare, [41,42,43,44], 'basic leave &?BLOCK: returns valid list in list context';
-}
+      is @bare, [41,42,43,44], 'basic leave &?BLOCK: returns valid list in list context';
+    }
 
-{
-  my @bare = [41, do { 21 + (leave &?BLOCK: 42, 43) + 23 }, 44 ];
+    {
+      my @bare = [41, do { 21 + (leave &?BLOCK: 42, 43) + 23 }, 44 ];
 
-  is @bare, [41,42,43,44], 'basic leave &?BLOCK: returns valid list in list context';
-}
+      is @bare, [41,42,43,44], 'basic leave &?BLOCK: returns valid list in list context';
+    }
 
-{
-  my $sub = sub () {
-    my $bare = { leave 42; 23 };
+    {
+      my $sub = sub () {
+        my $bare = { leave 42; 23 };
 
-    my $ret = $bare();
-    return 1000 + $ret;
-  };
+        my $ret = $bare();
+        return 1000 + $ret;
+      };
 
-  is $sub(), 1042, 'leave() works and leaves only the innermost block';
-}
+      is $sub(), 1042, 'leave() works and leaves only the innermost block';
+    }
 
-{
-  my $sub = sub () {
-    &?ROUTINE.leave(42);
-    return 23;
-  };
-
-  is $sub(), 42, 'leave() works with &?ROUTINE as invocant';
-}
-
-{
-  my $outer = sub () {
-    my $inner = sub () {
-      my $most_inner = sub () {
-        leave $outer: 42;
+    {
+      my $sub = sub () {
+        &?ROUTINE.leave(42);
         return 23;
       };
 
-      $most_inner();
-      return 22;
-    };
-
-    $inner();
-    return 21;
-  }
-
-  is $outer(), 42, 'nested leave() works with a subref as invocant';
-}
-
-{
-  my $sub = sub () {
-    my $bare = sub () {
-      Block.leave: 42;
-      return 23;
-    };
-
-    my $ret = $bare();
-    return 1000 + $ret;
-  };
-
-  is $sub(), 1042, 'leave() works with a Class (Block) as invocant';
-}
-
-{
-  my $sub = sub () {
-    my $bare = sub () {
-      leave Sub: 42;
-      return 23;
-    };
-
-    my $ret = $bare();
-    return 1000 + $ret;
-  };
-
-  is $sub(), 42, 'leave() works with a Class (Sub) as invocant';
-}
-
-{
-  my $sub = sub () {
-    LABEL: for 1..10 -> $n {
-	for 'a' .. 'b' -> $a {
-	    LABEL.leave(42);
-	    "$a,$n";
-	}
+      is $sub(), 42, 'leave() works with &?ROUTINE as invocant';
     }
-  }
 
-  is $sub(), 42, 'leave() works with a loop label';
-}
+    {
+      my $outer = sub () {
+        my $inner = sub () {
+          my $most_inner = sub () {
+            leave $outer: 42;
+            return 23;
+          };
 
-EVAL q[[
-  my $sub = sub () {
-    eager do			# XXX without eager would require time travel
-    LABEL: for 1..10 -> $n {
-	for 'a' .. 'b' -> $a {
-	    LABEL.leave(42,43);	# note, must cancel ordinary list comprehension!
-	    "$a,$n";
-	}
+          $most_inner();
+          return 22;
+        };
+
+        $inner();
+        return 21;
+      }
+
+      is $outer(), 42, 'nested leave() works with a subref as invocant';
     }
-  }
 
-  is [$sub()], [42,43], 'leave() works with a loop label in list context';
-]];
+    {
+      my $sub = sub () {
+        my $bare = sub () {
+          Block.leave: 42;
+          return 23;
+        };
 
-EVAL q[[
-  my $sub = sub () {
-    do LABEL: {
-	LABEL.leave(42);
-    } + 1000;
-  }
+        my $ret = $bare();
+        return 1000 + $ret;
+      };
 
-  is $sub(), 1042, 'leave() works with an internal do label';
-]];
+      is $sub(), 1042, 'leave() works with a Class (Block) as invocant';
+    }
+
+    {
+      my $sub = sub () {
+        my $bare = sub () {
+          leave Sub: 42;
+          return 23;
+        };
+
+        my $ret = $bare();
+        return 1000 + $ret;
+      };
+
+      is $sub(), 42, 'leave() works with a Class (Sub) as invocant';
+    }
+
+    {
+      my $sub = sub () {
+        LABEL: for 1..10 -> $n {
+    	for 'a' .. 'b' -> $a {
+    	    LABEL.leave(42);
+    	    "$a,$n";
+    	}
+        }
+      }
+
+      is $sub(), 42, 'leave() works with a loop label';
+    }
+
+    EVAL q[[
+      my $sub = sub () {
+        eager do			# XXX without eager would require time travel
+        LABEL: for 1..10 -> $n {
+    	for 'a' .. 'b' -> $a {
+    	    LABEL.leave(42,43);	# note, must cancel ordinary list comprehension!
+    	    "$a,$n";
+    	}
+        }
+      }
+
+      is [$sub()], [42,43], 'leave() works with a loop label in list context';
+    ]];
+
+    EVAL q[[
+      my $sub = sub () {
+        do LABEL: {
+    	LABEL.leave(42);
+        } + 1000;
+      }
+
+      is $sub(), 1042, 'leave() works with an internal do label';
+    ]];
+}
 
 # vim: expandtab shiftwidth=4

--- a/S05-modifier/exhaustive.t
+++ b/S05-modifier/exhaustive.t
@@ -1,6 +1,6 @@
 use v6;
 use Test;
-plan 11;
+plan 104;
 
 =begin pod
 
@@ -13,47 +13,47 @@ version 0.3 (12 Apr 2004), file t/exhaustive.t.
 
 my $str = "abrAcadAbbra";
 
-my @expected = (
-    [ 0 => 'abrAcadAbbra' ],
-    [ 0 => 'abrAcadA'     ],
-    [ 0 => 'abrAca'       ],
-    [ 0 => 'abrA'         ],
-    [ 3 =>    'AcadAbbra' ],
-    [ 3 =>    'AcadA'     ],
-    [ 3 =>    'Aca'       ],
-    [ 5 =>      'adAbbra' ],
-    [ 5 =>      'adA'     ],
-    [ 7 =>        'Abbra' ],
-);
+my @expected =
+    [ 0, 'abrAcadAbbra' ],
+    [ 0, 'abrAcadA'     ],
+    [ 0, 'abrAca'       ],
+    [ 0, 'abrA'         ],
+    [ 3,    'AcadAbbra' ],
+    [ 3,    'AcadA'     ],
+    [ 3,    'Aca'       ],
+    [ 5,      'adAbbra' ],
+    [ 5,      'adA'     ],
+    [ 7,        'Abbra' ],
+;
 
 for (1..2) -> $rep {
     ok($str ~~ m:i:exhaustive/ a .+ a /, "Repeatable every-way match ($rep)" );
 
-    ok(@$/ == @expected, "Correct number of matches ($rep)" );
-    my %expected; %expected{map {$_[1]}, @expected} = (1) x @expected;
-    my %position; %position{map {$_[1]}, @expected} = map {$_[0]}, @expected;
-    for (@$/) {
-        ok( %expected{$_}, "Matched '$_' ($rep)" );
-        ok( %position{$_} == $_.pos, "At correct position of '$_' ($rep)" );
-        #?rakudo emit #
-        %expected{$_} :delete;
-        #?rakudo emit %expected{$_}:delete
+    is +@$/, +@expected, "Correct number of matches (pass $rep)";
+    my %position;
+    for @expected -> ($pos, $exp) {
+        %position{$exp} = $pos;
     }
-    ok(%expected.keys == 0, "No matches missed ($rep)" );
+    for (@$/) {
+        ok %position{$_}:exists, "Matched '$_' ($rep)";
+        is .from, %position{$_}, "At correct position of '$_' ($rep)";
+        %position{$_}:delete;
+    }
+    is +%position, 0, "No matches missed ($rep)";
 }
 
-ok(!( "abcdefgh" ~~ m:exhaustive/ a .+ a / ), 'Failed every-way match');
-ok(@$/ == 0, 'No matches');
+nok "abcdefgh" ~~ m:exhaustive/ a .+ a /, 'Failed every-way match';
+is +@$/, 0, 'No matches';
 
-ok($str ~~ m:ex:i/ a (.+) a /, 'Capturing every-way match');
+ok $str ~~ m:ex:i/ a (.+) a /, 'Capturing every-way match';
 
-ok(@$/ == @expected, 'Correct number of capturing matches');
-my %expected; %expected{map {$_[1]}, @expected} = (1) x @expected;
+is +@$/, +@expected, 'Correct number of capturing matches';
+
+my %expected = |(@expected.map: { $_[1] => True });
 
 for @($/) {
-    ok( %expected{$_}, "Capture matched '$_'" );
-    ok( $_[1] = substr($_[0],1,-1), "Captured within '$_'" );
-    %expected{$_} :delete;
+    ok %expected{$_}, "Capture matched '$_'";
+    is $_[0], substr($_,1,*-1), "Captured within '$_'";
 }
 
 my @adj  = <time>;
@@ -103,45 +103,40 @@ is(~$/[2]<art>,  'an',    'Capture 2 art');
 is(~$/[2]<noun>, 'arrow', 'Capture 2 noun');
 
 
-regex subj  { <?noun> }
-regex obj   { <?noun> }
-regex noun  { time | flies | arrow }
-regex verb  { flies | like | time }
-regex adj   { time }
-regex art   { an? }
-regex prep  { like }
+my regex noun  { time | flies | arrow }
+my regex subj  { <noun> }
+my regex obj   { <noun> }
+my regex verb  { flies | like | time }
+my regex adj   { time }
+my regex art   { an? }
+my regex prep  { like }
 
-skip-rest("XXX - infinite loop"); exit;
+#skip-rest("XXX - infinite loop"); exit;
 
-ok("time   flies   like    an     arrow" ~~
-    m:s:ex/^ [ <adj>  <subj> <verb> <art> <obj>
-                 | <subj> <verb> <prep> <art> <noun>
-                 | <verb> <obj>  <prep> <art> <noun>
-                 ]
-         /,
-    "Any with capturing rules"
-);
+ok "time   flies   like    an     arrow" ~~
+    m:s:ex/^[<adj>   <subj>   <verb>    <art>     <obj>|<subj>   <verb>   <prep>    <art>     <noun>|<verb>   <obj>   <prep>    <art>     <noun>]/,
+    "Any with capturing rules";
 
-is(~$/[0]<adj>,  'time',  'Rule capture 0 adj');
-is(~$/[0]<subj>, 'flies', 'Rule capture 0 subj');
-is(~$/[0]<verb>, 'like',  'Rule capture 0 verb');
-is(~$/[0]<art>,  'an',    'Rule capture 0 art');
-is(~$/[0]<obj>,  'arrow', 'Rule capture 0 obj');
+is ~$/[0]<adj>,  'time',  'Rule capture 0 adj';
+is ~$/[0]<subj>, 'flies', 'Rule capture 0 subj';
+is ~$/[0]<verb>, 'like',  'Rule capture 0 verb';
+is ~$/[0]<art>,  'an',    'Rule capture 0 art';
+is ~$/[0]<obj>,  'arrow', 'Rule capture 0 obj';
 
-is(~$/[1]<subj>, 'time',  'Rule capture 1 subj');
-is(~$/[1]<verb>, 'flies', 'Rule capture 1 verb');
-is(~$/[1]<prep>, 'like',  'Rule capture 1 prep');
-is(~$/[1]<art>,  'an',    'Rule capture 1 art');
-is(~$/[1]<noun>, 'arrow', 'Rule capture 1 noun');
+is ~$/[1]<subj>, 'time',  'Rule capture 1 subj';
+is ~$/[1]<verb>, 'flies', 'Rule capture 1 verb';
+is ~$/[1]<prep>, 'like',  'Rule capture 1 prep';
+is ~$/[1]<art>,  'an',    'Rule capture 1 art';
+is ~$/[1]<noun>, 'arrow', 'Rule capture 1 noun';
 
-is(~$/[2]<verb>, 'time',  'Rule capture 2 verb');
-is(~$/[2]<obj>,  'flies', 'Rule capture 2 obj');
-is(~$/[2]<prep>, 'like',  'Rule capture 2 prep');
-is(~$/[2]<art>,  'an',    'Rule capture 2 art');
-is(~$/[2]<noun>, 'arrow', 'Rule capture 2 noun');
+is ~$/[2]<verb>, 'time',  'Rule capture 2 verb';
+is ~$/[2]<obj>,  'flies', 'Rule capture 2 obj';
+is ~$/[2]<prep>, 'like',  'Rule capture 2 prep';
+is ~$/[2]<art>,  'an',    'Rule capture 2 art';
+is ~$/[2]<noun>, 'arrow', 'Rule capture 2 noun';
 
 
-ok(!( "fooooo" ~~ m:exhaustive { s o+ } ), 'Subsequent failed any match...');
-    ok(@$/ == 0, '...leaves @$/ empty');
+nok "fooooo" ~~ m:exhaustive { s o+ }, 'Subsequent failed any match...';
+is +@$/, 0, '...leaves @$/ empty';
 
 # vim: expandtab shiftwidth=4

--- a/S05-modifier/ratchet.t
+++ b/S05-modifier/ratchet.t
@@ -7,7 +7,7 @@ plan 5;
 # S05-mass/rx.t
 
 # backtracking
-regex aplus { a+ };
+my regex aplus { a+ };
 
 ok 'aaaa'  ~~ m/ ^ <aplus> a $ /, 'normal regexes backtrack into subrules';
 ok 'aaaa' !~~ m/ :ratchet ^ <aplus> a $ /, ' ... but not with :ratchet';
@@ -16,6 +16,7 @@ ok 'aaaa' !~~ m/ :ratchet ^ <aplus> a $ /, ' ... but not with :ratchet';
 # normal. See http://irclog.perlgeek.de/perl6/2009-10-12#i_1595951 for a
 # discussion
 
+#?rakudo todo "Dubios test. Does it have to be this way?"
 ok 'aaaa' !~~ m/ :ratchet ^ [ :!ratchet <aplus> ] a /,
    'if the failing atom is outside the :!ratchet group: no backtracking';
 ok 'aaaa'  ~~ m/ :ratchet ^ [ :!ratchet <aplus> a ]  /,

--- a/S06-advanced/dispatching.t
+++ b/S06-advanced/dispatching.t
@@ -1,259 +1,282 @@
 use v6;
 use Test;
 use soft;
-plan 4;
+plan 6;
 
-#?rakudo todo 'Until 2020 dispatcher proposal is implemented'
-subtest "Dispatcher Chain" => {
-    plan 13;
-    my @order;
-    my class C1 {
-        method foo(|) { @order.push: ::?CLASS.^name }
+#?rakudo todo "This is canary test. If this TODO passes then it's probably the time to unfudge the main tests"
+# This block is to be removed when time comes.
+{
+    my class Foo {
+        method foo($v) {
+            $v * 2
+        }
     }
 
-    my class C2  is C1 {
-        proto method foo(|) {*}
-        multi method foo(Str $s) {
-            @order.push: ::?CLASS.^name ~ "(Str)";
-            nextsame;
-        }
-        multi method foo(Int $s) {
-            @order.push: ::?CLASS.^name ~ "(Int)";
-            nextsame;
-        }
-        multi method foo(Num) {
-            @order.push: ::?CLASS.^name ~ "(Num)";
+    my class Bar is Foo {
+        multi method foo(Int $v) {
             nextsame
         }
-    }
-
-    my class C3 is C2 {
-        method foo(|) {
-            @order.push: ::?CLASS.^name;
-            nextsame
+        multi method foo(Str $v) {
+            nextwith $v.Int
         }
     }
 
-    my class C4 is C3 {
-        proto method foo(|) {*}
-        multi method foo(Int:D $v) {
-            @order.push: ::?CLASS.^name ~ "(Int:D)";
-            nextwith ~$v
-        }
-        multi method foo(Any) {
-            @order.push: ::?CLASS.^name ~ "(Any)";
-            callsame
-        }
-    }
-
-    my $inst;
-
-    $inst = C3.new;
-    $inst.foo("bar");
-    is-deeply @order.List, <C3 C2(Str) C1>, "a multi-method doesn't break MRO dispatching";
-    @order = [];
-    $inst.foo(42);
-    is-deeply @order.List, <C3 C2(Int) C1>, "a multi-method dispatching works correctly";
-
-    $inst = C4.new;
-    @order = [];
-    $inst.foo("baz");
-    is-deeply @order.List, <C4(Any) C3 C2(Str) C1>, "multi being the first method in MRO still works";
-    @order = [];
-    $inst.foo(13);
-    is-deeply @order.List, <C4(Int:D) C4(Any) C3 C2(Str) C1>, "nextwith does what's expected";
-
-    my \proto := C2.^find_method('foo', :local, :no_fallback);
-
-    nok proto.is_wrapped, "proto is not wrapped yet";
-    my $wh1 = proto.wrap(my method foo-wrap(|) { @order.push: "foo-proto"; nextsame });
-    ok proto.is_wrapped, "proto is wrapped now";
-
-    @order = [];
-    $inst.foo("");
-    is-deeply @order.List, <C4(Any) C3 foo-proto C2(Str) C1>, "proto can be wrapped";
-
-    proto.unwrap($wh1);
-    @order = [];
-    $inst.foo("");
-    is-deeply @order.List, <C4(Any) C3 C2(Str) C1>, "proto can be unwrapped";
-
-    # This should be foo(Num) candidate
-    my \cand = proto.candidates[2];
-    # Note that next* can't be used with blocks.
-    $wh1 = cand.wrap(-> *@ { @order.push('foo-num-wrap'); callsame });
-    @order = [];
-    $inst.foo(pi);
-    is-deeply @order.List, <C4(Any) C3 foo-num-wrap C2(Num) C1>, "we can wrap a candidate";
-
-    # We can even wrap a candidate with another multi. It works!
-    proto multi-wrap(|) {*}
-    multi multi-wrap(\SELF, Num) {
-        @order.push: "multi-wrap(Num)";
-        nextsame
-    }
-    multi multi-wrap(\SELF, Any) {
-        @order.push: "multi-wrap(Any)";
-        nextsame
-    }
-
-    my $wh2 = cand.wrap(&multi-wrap);
-    @order = [];
-    $inst.foo(pi);
-    is-deeply @order.List, <C4(Any) C3 multi-wrap(Num) multi-wrap(Any) foo-num-wrap C2(Num) C1>, "we can use a multi as a wrapper of a candidate";
-
-    cand.unwrap($wh1);
-    @order = [];
-    $inst.foo(pi);
-    is-deeply @order.List, <C4(Any) C3 multi-wrap(Num) multi-wrap(Any) C2(Num) C1>, "we can unwrap a multi";
-
-    # Even nastier thing: wrap a candidate of our wrapper!
-    my $wwh = &multi-wrap.candidates[1].wrap(sub wrap-wrapper(|) { @order.push: 'cand-wrap'; nextsame });
-    @order = [];
-    $inst.foo(pi);
-    is-deeply @order.List, <C4(Any) C3 multi-wrap(Num) cand-wrap multi-wrap(Any) C2(Num) C1>, "we can use a multi as a wrapper of a candidate";
-
-    # Unwrap the method candidate from the second wrapper. We then get the original behavior.
-    cand.unwrap($wh2);
-    @order = [];
-    $inst.foo(pi);
-    is-deeply @order.List, <C4(Any) C3  C2(Num) C1>, "we can use a multi as a wrapper of a candidate";
+    my $obj = Bar.new;
+    is $obj.foo(21), 42, "Int is dispatched";
+    is $obj.foo("11"), 22, "Str is dispatched";
 }
 
-#?rakudo todo 'Until 2020 dispatcher proposal is implemented'
-subtest "Regression: nextcallee" => {
-    plan 2;
-    my @order;
-    my class C1 {
-        method foo(|) {
-            @order.push: ::?CLASS.^name
+#?rakudo skip 'Until 2020 dispatcher proposal is implemented'
+#?DOES 4
+{
+    subtest "Dispatcher Chain" => {
+        plan 13;
+        my @order;
+        my class C1 {
+            method foo(|) { @order.push: ::?CLASS.^name }
         }
-    }
-    my class C2 is C1 {
-        method foo(|args) {
-            @order.push: ::?CLASS.^name;
-            my &callee = nextcallee;
-            self.&callee(|args)
+
+        my class C2  is C1 {
+            proto method foo(|) {*}
+            multi method foo(Str $s) {
+                @order.push: ::?CLASS.^name ~ "(Str)";
+                nextsame;
+            }
+            multi method foo(Int $s) {
+                @order.push: ::?CLASS.^name ~ "(Int)";
+                nextsame;
+            }
+            multi method foo(Num) {
+                @order.push: ::?CLASS.^name ~ "(Num)";
+                nextsame
+            }
         }
-    }
-    my class C3 is C2 {
-        method foo(|args) {
-            @order.push: ::?CLASS.^name;
+
+        my class C3 is C2 {
+            method foo(|) {
+                @order.push: ::?CLASS.^name;
+                nextsame
+            }
+        }
+
+        my class C4 is C3 {
+            proto method foo(|) {*}
+            multi method foo(Int:D $v) {
+                @order.push: ::?CLASS.^name ~ "(Int:D)";
+                nextwith ~$v
+            }
+            multi method foo(Any) {
+                @order.push: ::?CLASS.^name ~ "(Any)";
+                callsame
+            }
+        }
+
+        my $inst;
+
+        $inst = C3.new;
+        $inst.foo("bar");
+        is-deeply @order.List, <C3 C2(Str) C1>, "a multi-method doesn't break MRO dispatching";
+        @order = [];
+        $inst.foo(42);
+        is-deeply @order.List, <C3 C2(Int) C1>, "a multi-method dispatching works correctly";
+
+        $inst = C4.new;
+        @order = [];
+        $inst.foo("baz");
+        is-deeply @order.List, <C4(Any) C3 C2(Str) C1>, "multi being the first method in MRO still works";
+        @order = [];
+        $inst.foo(13);
+        is-deeply @order.List, <C4(Int:D) C4(Any) C3 C2(Str) C1>, "nextwith does what's expected";
+
+        my \proto := C2.^find_method('foo', :local, :no_fallback);
+
+        nok proto.is_wrapped, "proto is not wrapped yet";
+        my $wh1 = proto.wrap(my method foo-wrap(|) { @order.push: "foo-proto"; nextsame });
+        ok proto.is_wrapped, "proto is wrapped now";
+
+        @order = [];
+        $inst.foo("");
+        is-deeply @order.List, <C4(Any) C3 foo-proto C2(Str) C1>, "proto can be wrapped";
+
+        proto.unwrap($wh1);
+        @order = [];
+        $inst.foo("");
+        is-deeply @order.List, <C4(Any) C3 C2(Str) C1>, "proto can be unwrapped";
+
+        # This should be foo(Num) candidate
+        my \cand = proto.candidates[2];
+        # Note that next* can't be used with blocks.
+        $wh1 = cand.wrap(-> *@ { @order.push('foo-num-wrap'); callsame });
+        @order = [];
+        $inst.foo(pi);
+        is-deeply @order.List, <C4(Any) C3 foo-num-wrap C2(Num) C1>, "we can wrap a candidate";
+
+        # We can even wrap a candidate with another multi. It works!
+        proto multi-wrap(|) {*}
+        multi multi-wrap(\SELF, Num) {
+            @order.push: "multi-wrap(Num)";
             nextsame
         }
-    }
-    my $inst = C3.new;
-    @order = [];
-    $inst.foo;
-    is-deeply @order.List, <C3 C2 C1>, "checkpoint";
+        multi multi-wrap(\SELF, Any) {
+            @order.push: "multi-wrap(Any)";
+            nextsame
+        }
 
-    C2.^find_method('foo', :no_fallback, :local)
-        .wrap(
-            sub (|args) {
-                @order.push: 'C2::foo::wrapper';
+        my $wh2 = cand.wrap(&multi-wrap);
+        @order = [];
+        $inst.foo(pi);
+        is-deeply @order.List, <C4(Any) C3 multi-wrap(Num) multi-wrap(Any) foo-num-wrap C2(Num) C1>, "we can use a multi as a wrapper of a candidate";
+
+        cand.unwrap($wh1);
+        @order = [];
+        $inst.foo(pi);
+        is-deeply @order.List, <C4(Any) C3 multi-wrap(Num) multi-wrap(Any) C2(Num) C1>, "we can unwrap a multi";
+
+        # Even nastier thing: wrap a candidate of our wrapper!
+        my $wwh = &multi-wrap.candidates[1].wrap(sub wrap-wrapper(|) { @order.push: 'cand-wrap'; nextsame });
+        @order = [];
+        $inst.foo(pi);
+        is-deeply @order.List, <C4(Any) C3 multi-wrap(Num) cand-wrap multi-wrap(Any) C2(Num) C1>, "we can use a multi as a wrapper of a candidate";
+
+        # Unwrap the method candidate from the second wrapper. We then get the original behavior.
+        cand.unwrap($wh2);
+        @order = [];
+        $inst.foo(pi);
+        is-deeply @order.List, <C4(Any) C3  C2(Num) C1>, "we can use a multi as a wrapper of a candidate";
+    }
+
+    subtest "Regression: nextcallee" => {
+        plan 2;
+        my @order;
+        my class C1 {
+            method foo(|) {
+                @order.push: ::?CLASS.^name
+            }
+        }
+        my class C2 is C1 {
+            method foo(|args) {
+                @order.push: ::?CLASS.^name;
                 my &callee = nextcallee;
-                &callee(|args)
-            });
-    @order = [];
-    $inst.foo;
-    is-deeply @order.List, <C3 C2::foo::wrapper C2 C1>, "nextcallee doesn't break the dispatcher chain";
-}
-
-#?rakudo todo 'Until 2020 dispatcher proposal is implemented'
-subtest "Regression: broken chain" => {
-    plan 2;
-    # A stray $*NEXT-DISPATCHER could wrongfully be picked up by a dispatcher vivified by a nested routine invocation.
-    my @order;
-    my class C1 {
-        multi method foo {
-            @order.push: "C1::foo";
-            $.bar;
+                self.&callee(|args)
+            }
         }
-
-        proto method bar(|) {*}
-        multi method bar {
-            @order.push: "C1::bar";
-            nextsame
+        my class C3 is C2 {
+            method foo(|args) {
+                @order.push: ::?CLASS.^name;
+                nextsame
+            }
         }
+        my $inst = C3.new;
+        @order = [];
+        $inst.foo;
+        is-deeply @order.List, <C3 C2 C1>, "checkpoint";
+
+        C2.^find_method('foo', :no_fallback, :local)
+            .wrap(
+                sub (|args) {
+                    @order.push: 'C2::foo::wrapper';
+                    my &callee = nextcallee;
+                    &callee(|args)
+                });
+        @order = [];
+        $inst.foo;
+        is-deeply @order.List, <C3 C2::foo::wrapper C2 C1>, "nextcallee doesn't break the dispatcher chain";
     }
 
-    my class C2 is C1 {
-        proto method bar(|) {*}
-        multi method bar {
-            @order.push: "C2::bar";
-            nextsame
+    subtest "Regression: broken chain" => {
+        plan 2;
+        # A stray $*NEXT-DISPATCHER could wrongfully be picked up by a dispatcher vivified by a nested routine invocation.
+        my @order;
+        my class C1 {
+            multi method foo {
+                @order.push: "C1::foo";
+                $.bar;
+            }
+
+            proto method bar(|) {*}
+            multi method bar {
+                @order.push: "C1::bar";
+                nextsame
+            }
         }
 
-        method foo {
-            @order.push: "C2::foo";
-            nextsame;
+        my class C2 is C1 {
+            proto method bar(|) {*}
+            multi method bar {
+                @order.push: "C2::bar";
+                nextsame
+            }
+
+            method foo {
+                @order.push: "C2::foo";
+                nextsame;
+            }
         }
+
+        my $inst = C2.new;
+        $inst.bar;
+        is-deeply @order.List, <C2::bar C1::bar>, "control: multi dispatches as expected";
+        @order = [];
+        $inst.foo;
+        is-deeply @order.List, <C2::foo C1::foo C2::bar C1::bar>, "multi-dispatch is not broken";
     }
 
-    my $inst = C2.new;
-    $inst.bar;
-    is-deeply @order.List, <C2::bar C1::bar>, "control: multi dispatches as expected";
-    @order = [];
-    $inst.foo;
-    is-deeply @order.List, <C2::foo C1::foo C2::bar C1::bar>, "multi-dispatch is not broken";
-}
+    # GH Raku/problem-solving#170
+    subtest "Wrap parent's first multi-candidate" => {
+        plan 3;
+        my @order;
+        my $inst;
 
-# GH Raku/problem-solving#170
-#?rakudo todo 'Until 2020 dispatcher proposal is implemented'
-subtest "Wrap parent's first multi-candidate" => {
-    plan 3;
-    my @order;
-    my $inst;
-
-    my class C1 {
-        method foo(|) {
-            @order.push: 'C1::foo'
+        my class C1 {
+            method foo(|) {
+                @order.push: 'C1::foo'
+            }
         }
+
+        my class C2 is C1 {
+            proto method foo(|) {*}
+            multi method foo(Int) {
+                @order.push: 'C2::foo(Int)';
+                nextsame;
+            }
+            multi method foo(Any) {
+                @order.push: 'C2::foo(Any)';
+                nextsame;
+            }
+        }
+
+        my class C3 is C2 {
+            method foo(|) {
+                @order.push: 'C3::foo';
+                nextsame
+            }
+        }
+
+        my @orig-order = <C3::foo C2::foo(Int) C2::foo(Any) C1::foo>;
+        $inst = C3.new;
+        $inst.foo(42);
+        is-deeply @order, @orig-order, "control: multi-dispatch as expected";
+
+        my $wh = C2.^lookup('foo').candidates[0].wrap(
+            -> | {
+                @order.push: "C2::foo::wrapper";
+                callsame
+            }
+        );
+
+        @order = [];
+        $inst.foo(42);
+        is-deeply
+            @order.List,
+            <C3::foo C2::foo::wrapper C2::foo(Int) C2::foo(Any) C1::foo>,
+            "wrapping of the first candidate doesn't break the chain";
+
+        $wh.restore;
+
+        @order = [];
+        $inst.foo(42);
+        is-deeply @order, @orig-order, "unwrapping of the candidate restores the order";
     }
-
-    my class C2 is C1 {
-        proto method foo(|) {*}
-        multi method foo(Int) {
-            @order.push: 'C2::foo(Int)';
-            nextsame;
-        }
-        multi method foo(Any) {
-            @order.push: 'C2::foo(Any)';
-            nextsame;
-        }
-    }
-
-    my class C3 is C2 {
-        method foo(|) {
-            @order.push: 'C3::foo';
-            nextsame
-        }
-    }
-
-    my @orig-order = <C3::foo C2::foo(Int) C2::foo(Any) C1::foo>;
-    $inst = C3.new;
-    $inst.foo(42);
-    is-deeply @order, @orig-order, "control: multi-dispatch as expected";
-
-    my $wh = C2.^lookup('foo').candidates[0].wrap(
-        -> | {
-            @order.push: "C2::foo::wrapper";
-            callsame
-        }
-    );
-
-    @order = [];
-    $inst.foo(42);
-    is-deeply
-        @order.List,
-        <C3::foo C2::foo::wrapper C2::foo(Int) C2::foo(Any) C1::foo>,
-        "wrapping of the first candidate doesn't break the chain";
-
-    $wh.restore;
-
-    @order = [];
-    $inst.foo(42);
-    is-deeply @order, @orig-order, "unwrapping of the candidate restores the order";
 }
 
 done-testing;

--- a/S06-macros/postfix.t
+++ b/S06-macros/postfix.t
@@ -6,6 +6,7 @@ use experimental :macros;
 plan 1;
 
 # L<S06/Macros>
+# XXX This test is likely to be reconsidered after the release of RakuAST
 
 macro postfix:<!> (Int $n) {
     my $factorial = [*] 1..$n;

--- a/S06-macros/returning-closure.t
+++ b/S06-macros/returning-closure.t
@@ -4,6 +4,7 @@ use Test;
 use experimental :macros;
 
 #L<S06/"Macros">
+# XXX This test is likely to be reconsidered after the release of RakuAST
 
 plan 4;
 
@@ -14,7 +15,7 @@ plan 4;
   macro returns_a_closure {
     my $x = 42;
     $in_macro = 1;
-    return { $in_macro_clos++; 100 + $x + $z };
+    quasi { {{}}{ $in_macro_clos++; 100 + $x + $z } };
   }
 
   is $in_macro,           1, "macro was executed during compile time";

--- a/S06-macros/returning-string.t
+++ b/S06-macros/returning-string.t
@@ -4,6 +4,7 @@ use Test;
 use experimental :macros;
 
 # L<S06/Macros>
+# XXX This test is likely to be reconsidered after the release of RakuAST
 
 plan 8;
 

--- a/S10-packages/export.t
+++ b/S10-packages/export.t
@@ -2,7 +2,7 @@ use v6;
 use Test;
 
 # L<S11/Exportation>
-use lib $?FILE.IO.parent.child("packages/Export_Pack/lib");
+use lib $?FILE.IO.parent(2).child("packages/Export_Pack/lib");
 
 plan 7;
 

--- a/S10-packages/scope.t
+++ b/S10-packages/scope.t
@@ -7,7 +7,7 @@ use lib $?FILE.IO.parent(2).add("packages/PackageTest/lib");
 # test that packages work.  Note that the correspondance between type
 # objects as obtained via the ::() syntax and packages is only hinted
 # at in L<S10/Packages/or use the sigil-like>
-plan 23;
+plan 24;
 
 # 4 different ways to be imported
 # L<S10/Packages/A bare>
@@ -80,11 +80,15 @@ ok($pkg !=== ::('PackageTest::My::Package'), 'not the same as global type object
 
 # Check temporization of variables in external packages
 {
-  {
-    ok(EVAL('temp $Test2::scalar; 1'), "parse for temp package vars");
-    $Test2::scalar++;
-  }
-  is($Test2::scalar, 42, 'temporization of external package variables');
+    # Use try because EVAL throws if parse fails.
+    ok(my $rval = try { EVAL('temp $Test2::scalar; ++$Test2::scalar') }, "parse for temp package vars");
+    with $rval {
+        is $rval, 43, "scope returns value of a modified temp scalar";
+    }
+    else {
+        skip "can't test for value because scope compile failed";
+    }
+    is($Test2::scalar, 42, 'temporization of external package variables');
 }
 
 # vim: expandtab shiftwidth=4

--- a/S12-attributes/augment-and-initialization.t
+++ b/S12-attributes/augment-and-initialization.t
@@ -16,15 +16,15 @@ diag('Test for class attribute initialization');
 {
 	class T1 { }
 	class T2 { }
-	eval-lives-ok 'use MONKEY-TYPING; augment class T1 { has $.t = 1 }; 1',
+	eval-lives-ok 'use MONKEY-TYPING; augment class T1 { has $.t = 1 };',
 		"Try to initialize public attribute";
 
-        eval-lives-ok q'
+    eval-lives-ok q'
 		use MONKEY-TYPING;
 		augment class T2 {
 		    has $!t = 2;
 		    method get { $!t };
-		}; 1 }',
+		};',
 		"Try to initialize private attribute";
 
 
@@ -33,19 +33,23 @@ diag('Test for class attribute initialization');
 
 	$o1 = T1.new();
 	$o2 = T2.new();
+#?rakudo eval "Unimplemented yet"
 	is $o1.t, 1,
 		"Testing value for initialized public attribute.";
 	dies-ok { $o2.t },
 		"Try to access the initialized private attribute.";
+#?rakudo todo "Augmentation attributes support is not implemented"
 	is try { $o2.get }, 2,
 		"Testing value for initialized private attribue.";
 
 	$o1 = T1.new( t => 3 );
 	$o2 = T2.new( t => 4 );
+#?rakudo eval "Unimplemented yet"
 	is $o1.t, 3,
 		"Testing value for attributes which is initialized by constructor.";
 	dies-ok { $o2.t },
 		"Try to access the private attribute which is initialized by constructor.";
+#?rakudo todo "Augmentation attributes support is not implemented"
 	is try { $o2.get }, 4,
 		"Testing value for private attribue which is initialized by constructor.";
 }

--- a/S13-syntax/aliasing.t
+++ b/S13-syntax/aliasing.t
@@ -2,32 +2,42 @@ use v6;
 
 use Test;
 
-plan 3;
+plan 5;
 
 # L<S13/Syntax/This can easily be handled with Raku's aliasing>
 
-class Foo {
-  method bar()     { 42 }
-  method bar_ref() { &bar }
-}
+# XXX When the two canary tests pass TODO it is time to remove them and unfudge the main test body.
+#?rakudo todo "Canary test for &method"
+eval-lives-ok 'my class Foo { method bar() {}; method bar_ref() { &bar } }', '&method is implemented, consider unfudging this test';
 
+#?rakudo todo "Canary test for ::="
+eval-lives-ok 'my $foo = 42; my $bar ::= $foo;', '::= is implemented, consider unfudging this test';
+
+#?rakudo eval "Requires &method and ::= to be implemented"
 {
-  my $foo = Foo.new;
-  lives-ok { $foo.bar_ref }, "returning a method reference works";
-}
+    my class Foo {
+      method bar()     { 42 }
+      method bar_ref() { &bar }
+    }
 
-class Baz {
-    method bar() { 42 }
-    our &baz ::= &bar;
-}
+    {
+      my $foo = Foo.new;
+      lives-ok { $foo.bar_ref }, "returning a method reference works";
+    }
 
-{
-  my $ret;
-  lives-ok {
-    my $baz = Baz.new;
-    $ret    = $baz.baz();
-  }, "calling an aliased method worked";
-  is $ret, 42, "the aliased method returned the right thing";
+    my class Baz {
+        method bar() { 42 }
+        our &baz ::= &bar;
+    }
+
+    {
+      my $ret;
+      lives-ok {
+        my $baz = Baz.new;
+        $ret    = $baz.baz();
+      }, "calling an aliased method worked";
+      is $ret, 42, "the aliased method returned the right thing";
+    }
 }
 
 # vim: expandtab shiftwidth=4

--- a/S14-roles/attributes-6e.t
+++ b/S14-roles/attributes-6e.t
@@ -27,11 +27,11 @@ my role R3 does R1 does R2 {
 
 class C does R3 {
     submethod attr-val {
-        $?CLASS.^name ~ ":" ~ $.foo
+        $?CLASS.^name ~ ":" ~ self.foo
     }
 }
 
-is-deeply C.new(:foo(-42)).+attr-val, ('C:-42', 'R3:-42', 'R1:-42', 'R2:-42', 'R0:-42'),
+is-deeply C.new(:foo(-42)).WALK('attr-val', :roles)().List, ('C:-42', 'R3:-42', 'R1:-42', 'R2:-42', 'R0:-42'),
             "same attribute is used across all roles";
 
 

--- a/S14-roles/composition.t
+++ b/S14-roles/composition.t
@@ -74,7 +74,6 @@ ok rB !~~ RT64002, 'role not matched by second role it does';
 
 # diamond composition
 # https://github.com/Raku/old-issue-tracker/issues/2593
-#?rakudo skip 'diamond composition RT #124749'
 {
     role DA { 
         method foo { "OH HAI" };

--- a/S14-traits/package.t
+++ b/S14-traits/package.t
@@ -1,22 +1,19 @@
 use v6;
 use Test;
 
-plan 8;
+plan 4;
 
 # L<S14/Traits/>
 
-role description {
-    has $.description is rw;
+role Description[Any $desc] {
+    has $.description is rw = $desc;
 }
 
-multi trait_mod:<is>(Mu:U $c, description, $arg) {
-    $c.HOW does description($arg);
+multi trait_mod:<is>(Mu:U $c is raw, Str:D :$description, ) {
+    $c.HOW does Description[$description];
 }
-multi trait_mod:<is>(Mu:U $c, description) {
-    $c.HOW does description("missing description!");
-}
-multi trait_mod:<is>(Mu:U $c, :$described!) {
-    $c.HOW does description($described ~~ Str ?? $described !! "missing description");
+multi trait_mod:<is>(Mu:U $c, Any :$description!) {
+    $c.HOW does Description["missing description!"];
 }
 
 class Monkey is description('eats bananas, awesome') { }
@@ -24,20 +21,9 @@ class Walrus is description { }
 is Monkey.HOW.description, 'eats bananas, awesome', 'description role applied to class and set with argument';
 is Walrus.HOW.description, 'missing description!',  'description role applied to class without argument';
 
-class Badger is described('mushroom mushroom') { }
-class Snake is described { }
-is Badger.HOW.description, 'mushroom mushroom',    'named trait handler applied other role to class set with argument';
-is Snake.HOW.description,  'missing description!', 'named trait handler applied other role to class without argument';
-
-
 role Nom is description('eats and eats') { }
 role Loser is description { }
-is Nom.HOW.description,   'eats and eats',        'description role applied to role and set with argument';
-is Loser.HOW.description, 'missing description!', 'description role applied to role without argument';
-
-role DamBuilding is described('dam good!') { }
-role Slither is described { }
-is DamBuilding.HOW.description, 'dam good!',            'named trait handler applied other role to role set with argument';
-is Slither.HOW.description,     'missing description!', 'named trait handler applied other role to role without argument';
+is Nom.^candidates[0].HOW.description,   'eats and eats',        'description role applied to role and set with argument';
+is Loser.^candidates[0].HOW.description, 'missing description!', 'description role applied to role without argument';
 
 # vim: expandtab shiftwidth=4

--- a/S14-traits/variables.t
+++ b/S14-traits/variables.t
@@ -6,13 +6,15 @@ plan 5;
 # L<S14/Traits/>
 
 my @var_names;
-multi trait_mod:<is>($a, :$noted!) {
+multi trait_mod:<is>(Variable:D $a, :$noted!) {
     push @var_names, $a.VAR.name;
 }
 
-role doc { has $.doc is rw }
-multi trait_mod:<is>($a, $arg, :$doc!) {
-    $a.container.VAR does doc.new(doc => $arg);
+role Doc[Str:D $doc] {
+    has $.doc is rw = $doc;
+}
+multi trait_mod:<is>(Variable:D $a, Str:D :$doc!) {
+    $a.var.VAR does Doc[$doc];
 }
 
 
@@ -25,12 +27,12 @@ is +@var_names, 3, 'have correct number of names noted from trait applied by nam
 is @var_names, ['$a','%b','@c'], 'trait recorded correct information';
 
 
-my $dog is doc('barks');
+my $dog   is doc('barks');
 my @birds is doc('tweet');
-my %cows is doc('moooo');
+my %cows  is doc('moooo');
 
-is $dog.VAR.doc, 'barks', 'trait applied to scalar variable correctly';
-is @birds.doc,   'tweet', 'trait applied to array variable correctly';
-is %cows.doc,    'moooo', 'trait applied to hash variable correctly';
+is $dog.VAR.doc,   'barks', 'trait applied to scalar variable correctly';
+is @birds.VAR.doc, 'tweet', 'trait applied to array variable correctly';
+is %cows.VAR.doc,  'moooo', 'trait applied to hash variable correctly';
 
 # vim: expandtab shiftwidth=4

--- a/S16-unfiled/getpeername.t
+++ b/S16-unfiled/getpeername.t
@@ -13,6 +13,8 @@ IO.getpeername test
 plan 1;
 
 my $sock = IO::Socket::INET.connect('google.com', 80);
-ok $sock.getpeername.defined, "IO::Socket::INet.getpeername works";
+#?rakudo todo "getpeername is not implemented yet"
+# It's better to remove try when the TODO passes. Though more testing would then be needed anyway, I guess.
+ok (try $sock.getpeername.defined), "IO::Socket::INet.getpeername works";
 
 # vim: expandtab shiftwidth=4

--- a/S17-supply/watch-path.t
+++ b/S17-supply/watch-path.t
@@ -14,12 +14,19 @@ ok !$filename.IO.e, "make sure we don't have a file";
 given $*DISTRO.name {
     when "macosx" {
 #?rakudo.jvm 3 skip "file system events NYI?"
+#?DOES 1
+{
         subtest &macosx, "does watch-path work on Mac OS X";
+}
 
         unlink $filename; # in case we missed the cleanup
         ok !$filename.IO.e, "make sure we don't have a file (2)";
 
+#?rakudo.jvm 3 skip "file system events NYI?"
+#?DOES 1
+{
         subtest { macosx :io-path }, "does IO::Path.watch work on Mac OS X";
+}
     }
     default {
         skip "Only OSX tests available", 3;

--- a/S24-testing/2-force_todo.t
+++ b/S24-testing/2-force_todo.t
@@ -1,20 +1,27 @@
 use v6;
 use Test;
 
-plan 11;
+plan 12;
 
-force_todo(1, 3, 5, 7 .. 9, 11);
+#?rakudo eval "Module Test doesn't implement force_todo yet"
+{
+    force_todo(1, 3, 5, 7 .. 9, 11);
 
-flunk("This will fail, but will be forced-TODO by force_todo()");
-pass("This will pass normally");
-flunk("This will fail, but will be forced-TODO by force_todo()");
-pass("This will pass normally");
-flunk("This will TODO fail, and will be forced-TODO by force_todo()", :todo(1));
-pass("This will pass normally");
-flunk("This will fail, and will be forced-TODO by force_todo()");
-flunk("This will fail, and will be forced-TODO by force_todo()");
-flunk("This will fail, and will be forced-TODO by force_todo()");
-pass("This will pass normally");
-flunk("This will fail, and will be forced-TODO by force_todo()");
+    flunk("This will fail, but will be forced-TODO by force_todo()");
+    pass("This will pass normally");
+    flunk("This will fail, but will be forced-TODO by force_todo()");
+    pass("This will pass normally");
+    flunk("This will TODO fail, and will be forced-TODO by force_todo()", :todo(1));
+    pass("This will pass normally");
+    flunk("This will fail, and will be forced-TODO by force_todo()");
+    flunk("This will fail, and will be forced-TODO by force_todo()");
+    flunk("This will fail, and will be forced-TODO by force_todo()");
+    pass("This will pass normally");
+    flunk("This will fail, and will be forced-TODO by force_todo()");
+}
+
+# XXX When this test passes it is likely the time to remove it and unfudge the main test body.
+#?rakudo todo "Canary test for &Test::force_todo"
+eval-lives-ok 'force_todo(12); flunk("failing on purpose")', "force_todo is implemented";
 
 # vim: expandtab shiftwidth=4

--- a/S26-documentation/12-non-breaking-space.t
+++ b/S26-documentation/12-non-breaking-space.t
@@ -3,22 +3,6 @@ use v6;
 use MONKEY-SEE-NO-EVAL;
 use Test;
 
-my $code = gen-test();
-EVAL $code;
-
-##### subroutines #####
-sub gen-test {
-    my $code = "";
-    # my $fh = open $f, :w;
-    #LEAVE try close $fh;
-
-    $code ~= q:to/HERE/;
-        use v6;
-
-        # two-column table with various whitespace chars
-        =begin table
-        HERE
-
     # non-breaking ws chars
     my @nbchars = [
         0x00A0, # NO-BREAK SPACE
@@ -55,6 +39,55 @@ sub gen-test {
         0x3000, # IDEOGRAPHIC SPACE
     ];
 
+##### some subroutines for the EVALed file #####
+sub int2hexstr($int, :$plain) {
+    # given an int, convert it to a hex string
+    if !$plain {
+        return sprintf("0x%04X", $int);
+    }
+    else {
+        return sprintf("%X", $int);
+    }
+}
+
+sub show-space-chars($str) {
+    # given a string with space chars, return a version with the
+    # hex code shown for them and place a pipe separating all
+    # chars in the original string
+    my @c = $str.comb;
+    my $new-str = '';
+    for @c -> $c {
+        $new-str ~= '|' if $new-str;
+        if $c ~~ /\s/ {
+            my $int = $c.ord;
+            my $hex-str = int2hexstr($int);
+            $new-str ~= $hex-str;
+        }
+        else {
+            =begin comment
+            $new-str ~= $c;
+            =end comment
+            my $int = $c.ord;
+            my $hex-str = int2hexstr($int, :plain);
+            $new-str ~= $hex-str;
+        }
+    }
+    return $new-str;
+}
+
+##### subroutines #####
+sub gen-pod {
+    my $code = "";
+    # my $fh = open $f, :w;
+    #LEAVE try close $fh;
+
+    my $pod;
+
+    $code ~= q:to/HERE/;
+        # two-column table with various whitespace chars
+        =begin table
+        HERE
+
     # make one testing row per non-breaking space char
     for @nbchars -> $nbc {
         # first column
@@ -77,86 +110,31 @@ sub gen-test {
         $code ~= "is the best!\n";
     }
     $code ~= "=end table\n";
+    $code ~= "\$pod = \$=pod[0]";
+    EVAL $code;
+    $pod
+}
 
-    my $n = +@nbchars;
-    # the planned num of tests is 1 + $n
-    $code ~= "plan 1 + $n * 2;\n";
-    $code ~= "my \$n = $n;\n";
-    $code ~= "my \$SPACE = ' ';\n";
-
-    $code ~= q:to/HERE/;
-        my $r = $=pod[0];
-        is $r.contents.elems, $n, "table has $n elements (rows)";
-        HERE
-
-    # create separate sub-tests for each non-breaking space char
-    for 0..^$n -> $i {
-        $code ~= "\n\{\n";
-        $code ~= "my \$i = $i;\n";
-        $code ~= "my \$row = $i + 1;\n";
-        $code ~= "my \$nbspc = \"{@nbchars[$i].chr}\";\n";
-
-        $code ~= q:to/HERE/;
-            my $res0 = "Raku{$nbspc}Language is the best!";
-            my $res1 = "Raku {$nbspc} Language is the best!";
-            # show cell chars separated by pipes
-            =begin comment
-            my $c0 = $r.contents[$i][0].comb.join('|');
-            my $r0 = $res0.comb.join('|');
-            my $c1 = $r.contents[$i][1].comb.join('|');
-            my $r1 = $res1.comb.join('|');
-            =end comment
-            my $c0 = show-space-chars($r.contents[$i][0]);
-            my $r0 = show-space-chars($res0);
-            my $c1 = show-space-chars($r.contents[$i][1]);
-            my $r1 = show-space-chars($res1);
-
-            is $r.contents[$i][0], $res0, "row $row, col 1: '$c0' vs '$r0'";
-            is $r.contents[$i][1], $res1, "row $row, col 2: '$c1' vs '$r1'";
-            HERE
-
-        $code ~= "}\n";
+my $pod = gen-pod;
+my $nbchar-count = +@nbchars;
+plan $nbchar-count + 1;
+is $pod.contents.elems, $nbchar-count, "table contains elems for all known non-breaking spaces";
+for 0..^$nbchar-count -> $i {
+    my $nbspc = @nbchars[$i].chr;
+    my $row = $i + 1;
+    subtest "Row $row, char 0x" ~ @nbchars[$i].base(16) => {
+        plan 4;
+        my $res0 = "Raku{$nbspc}Language is the best!";
+        my $res1 = "Raku {$nbspc} Language is the best!";
+        my $c0 = show-space-chars($pod.contents[$i][0]);
+        my $r0 = show-space-chars($res0);
+        my $c1 = show-space-chars($pod.contents[$i][1]);
+        my $r1 = show-space-chars($res1);
+        is $pod.contents[$i][0], $res0, "col 1: content matches";
+        is $c0, $r0, "col 1: all spaces match";
+        is $pod.contents[$i][1], $res1, "col 2: content matches";
+        is $c1, $r1, "col 2: all spaces match";
     }
-
-    $code ~= q:to/HERE/;
-        ##### some subroutines for the EVALed file #####
-        sub int2hexstr($int, :$plain) {
-            # given an int, convert it to a hex string
-            if !$plain {
-                return sprintf("0x%04X", $int);
-            }
-            else {
-                return sprintf("%X", $int);
-            }
-        }
-
-        sub show-space-chars($str) {
-            # given a string with space chars, return a version with the
-            # hex code shown for them and place a pipe separating all
-            # chars in the original string
-            my @c = $str.comb;
-            my $new-str = '';
-            for @c -> $c {
-                $new-str ~= '|' if $new-str;
-                if $c ~~ /\s/ {
-                    my $int = $c.ord;
-                    my $hex-str = int2hexstr($int);
-                    $new-str ~= $hex-str;
-                }
-                else {
-                    =begin comment
-                    $new-str ~= $c;
-                    =end comment
-                    my $int = $c.ord;
-                    my $hex-str = int2hexstr($int, :plain);
-                    $new-str ~= $hex-str;
-                }
-            }
-            return $new-str;
-        }
-        HERE
-
-    $code
 }
 
 done-testing;

--- a/S32-io/child-secure.t
+++ b/S32-io/child-secure.t
@@ -42,6 +42,7 @@ sub make-temp-dir (Int $chmod? --> IO::Path:D) {
 }
 
 sub failuring-like (&test, $ex-type, $reason?, *%matcher) {
+    todo $_ with $*NOT-IMPL-TODO;
     subtest $reason => sub {
         plan 2;
         CATCH { default {
@@ -65,21 +66,25 @@ sub is-path ($got, $expected, $desc) {
     cmp-ok $got.resolve, '~~', $expected.resolve, $desc
 }
 
-failuring-like { $non-resolving-parent.child('../foo', :secure) },
-  X::IO::Resolve,
-  'non-resolving parent fails (given path is non-child)';
+{
+#?rakudo emit my $*NOT-IMPL-TODO = "IO::Path doesn't implement :secure yet";
 
-failuring-like { $non-resolving-parent.child('foo', :secure) },
-  X::IO::Resolve,
-  'non-resolving parent fails (given path is child)';
+    failuring-like { $non-resolving-parent.child('../foo', :secure) },
+      X::IO::Resolve,
+      'non-resolving parent fails (given path is non-child)';
 
-failuring-like { $parent.child('foo/bar', :secure) },
-  X::IO::Resolve,
-  'resolving parent fails (given path is a child, but not resolving)';
+    failuring-like { $non-resolving-parent.child('foo', :secure) },
+      X::IO::Resolve,
+      'non-resolving parent fails (given path is child)';
 
-failuring-like { $parent.child('../foo', :secure) },
-  X::IO::NotAChild,
-  'resolved parent fails (given path is not a child)';
+    failuring-like { $parent.child('foo/bar', :secure) },
+      X::IO::Resolve,
+      'resolving parent fails (given path is a child, but not resolving)';
+
+    failuring-like { $parent.child('../foo', :secure) },
+      X::IO::NotAChild,
+      'resolved parent fails (given path is not a child)';
+}
 
 is-path $parent.child('foo', :secure), $parent.child('foo'),
   'resolved parent with resolving, non-existent child';
@@ -94,12 +99,16 @@ is-path $parent.child('foo/bar', :secure), $parent.child('foo/bar'),
 is-path $parent.child('foo/../bar', :secure), $parent.child('bar'),
     'resolved parent with resolving, non-existent child, with ../';
 
-failuring-like { $parent.child('foo/../../bar', :secure) },
-  X::IO::NotAChild,
-  'resolved parent fails (given path is not a child, via child + ../)';
+{
+#?rakudo emit my $*NOT-IMPL-TODO = "IO::Path doesn't implement :secure yet";
 
-failuring-like { $parent.child("../\x[308]", :secure) },
-  X::IO::NotAChild,
-  'resolved parent fails (given path is not a child, via combiners)';
+    failuring-like { $parent.child('foo/../../bar', :secure) },
+      X::IO::NotAChild,
+      'resolved parent fails (given path is not a child, via child + ../)';
+
+    failuring-like { $parent.child("../\x[308]", :secure) },
+      X::IO::NotAChild,
+      'resolved parent fails (given path is not a child, via combiners)';
+}
 
 # vim: expandtab shiftwidth=4

--- a/S32-list/toggle.t
+++ b/S32-list/toggle.t
@@ -4,55 +4,36 @@ use Test;
 # Tests for .toggle method
 plan 4;
 
-
-#?rakudo.jvm skip 'toggle hangs on JVM backend'
-#?DOES 1
-{
-  subtest 'general' => {
+subtest 'general' => {
     plan +my @types := ^10, (0, 1, 2, 3, 4, 5, 6, 7, 8, 9), [^10];
     for @types -> \t {
         subtest t.^name => {
             is-deeply t.toggle,      ^10 .Seq, 'no args';
             is-deeply t.toggle(:off),  ().Seq, 'no args (:off)';
-            is-deeply t.toggle(?*),    ().Seq,
-                '1 callable (toggles on first value)';
-            is-deeply t.toggle(!*),  (0,).Seq,
-                '1 callable (toggles on later value)';
-            is-deeply t.toggle(:off, ?*), (^9+1).Seq,
-                '1 callable (:off, toggles on first value)';
-            is-deeply t.toggle(:off, !*), ^10 .Seq,
-                '1 callable (:off, toggles on later value)';
+            is-deeply t.toggle(?*),    ().Seq, '1 callable (toggles on first value)';
+            is-deeply t.toggle(!*),  (0,).Seq, '1 callable (toggles on later value)';
+            is-deeply t.toggle(:off, ?*), (^9+1).Seq, '1 callable (:off, toggles on first value)';
+            is-deeply t.toggle(:off, !*), ^10 .Seq, '1 callable (:off, toggles on later value)';
 
             # 0 => off, toggle; 1..3 => off, 4 => on, toggle, 5 => off, toggle,
             # 6 => on, toggle, 7 => off, toggle, 8..* => off
-            is-deeply t.toggle(?*, * > 3, !*, * < 7, !*),       (4, 6).Seq,
-                'multi-callable';
+            is-deeply t.toggle(?*, * > 3, !*, * < 7, !*),       (4, 6).Seq, 'multi-callable';
             # 0 => off, 1 => on, toggle; 2 => off, toggle, 3..* => off
-            is-deeply t.toggle(:off, ?*, * > 3, !*, * < 7, !*), 1.Seq,
-                'multi-callable (:off)';
+            is-deeply t.toggle(:off, ?*, * > 3, !*, * < 7, !*), 1.Seq, 'multi-callable (:off)';
         }
     }
-  }
 }
 
-#?rakudo.jvm skip 'toggle hangs on JVM backend'
-#?DOES 1
-{
-  subtest 'chaining' => {
+subtest 'chaining' => {
     plan 3;
     is-deeply ^10 .toggle(* < 8).toggle(:off, * > 5), (6, 7).Seq, 'on, off';
-    is-deeply ^10 .skip(3).toggle(* < 8).grep(* < 7).toggle(:off, * > 5),
-        (6,).Seq, 'skip, on, grep, off';
+    is-deeply ^10 .skip(3).toggle(* < 8).grep(* < 7).toggle(:off, * > 5), (6,).Seq, 'skip, on, grep, off';
 
     my $s := ^60; for ^50+10 -> \v { $s := $s.toggle: * < v };
     is-deeply $s.List, ^10 .List, '50-toggle chain';
-  }
 }
 
-#?rakudo.jvm skip 'toggle hangs on JVM backend'
-#?DOES 1
-{
-  subtest 'empty sources' => {
+subtest 'empty sources' => {
     my @tests = $, (), [], Map.new, %(), set(), mix();
     @tests[0] := Empty; # can't just list it normally above; it will vanish
     plan +@tests;
@@ -61,23 +42,15 @@ plan 4;
             plan 6;
             is-deeply v.toggle,           ().Seq, 'no args';
             is-deeply v.toggle(:off),     ().Seq, 'no args (:off)';
-            is-deeply v.toggle(?*),       ().Seq,
-                '1 callable (toggles on first value)';
-            is-deeply v.toggle(!*),       ().Seq,
-                '1 callable (toggles on later value)';
-            is-deeply v.toggle(:off, ?*), ().Seq,
-                '1 callable (:off, toggles on first value)';
-            is-deeply v.toggle(:off, !*), ().Seq,
-                '1 callable (:off, toggles on later value)';
+            is-deeply v.toggle(?*),       ().Seq, '1 callable (toggles on first value)';
+            is-deeply v.toggle(!*),       ().Seq, '1 callable (toggles on later value)';
+            is-deeply v.toggle(:off, ?*), ().Seq, '1 callable (:off, toggles on first value)';
+            is-deeply v.toggle(:off, !*), ().Seq, '1 callable (:off, toggles on later value)';
         }
     }
-  }
 }
 
-#?rakudo.jvm skip 'toggle hangs on JVM backend'
-#?DOES 1
-{
-  subtest 'Non-Iterable objects' => {
+subtest 'Non-Iterable objects' => {
     is-deeply 42.toggle,               42.Seq, 'no args';
     is-deeply 42.toggle(:off),         ().Seq, 'no args (:off)';
     is-deeply 42.toggle(?*),           42.Seq, 'truthy callable';
@@ -85,7 +58,6 @@ plan 4;
     is-deeply 42.toggle(!*),           ().Seq, 'falsy callable';
     is-deeply 42.toggle(?*, !*),       42.Seq, 'multiple callables';
     is-deeply 42.toggle(:off, ?*, !*), 42.Seq, 'multiple callables (:off)';
-  }
 }
 
 # vim: expandtab shiftwidth=4

--- a/S32-str/space-chars.t
+++ b/S32-str/space-chars.t
@@ -1,5 +1,4 @@
 use v6;
-
 use Test;
 
 # non-breaking ws chars
@@ -62,6 +61,7 @@ for @bchars -> $hexint {
         my $char2 = 0x2002.chr;
         my $int2  = $char.ord;
         my $int2a = $char2.ord;
+        #?rakudo.jvm todo "JVM doesn't pass yet"
         cmp-ok $int2a, '==', $int2, "incoming hex '{int2hexstr($hexint)}' (gets normalized to 0x2002.chr)";
     }
     elsif $hexint == 0x2001 {
@@ -69,6 +69,7 @@ for @bchars -> $hexint {
         my $char2 = 0x2003.chr;
         my $int2 = $char.ord;
         my $int2a = $char2.ord;
+        #?rakudo.jvm todo "JVM doesn't pass yet"
         cmp-ok $int2a, '==', $int2, "incoming hex '{int2hexstr($hexint)}' (gets normalized to 0x2003.chr)";
     }
     else {

--- a/fudge
+++ b/fudge
@@ -203,6 +203,14 @@ else {
     print "$IN\n";  # pick the input file to run
 }
 
+sub wrap_eval {
+    my ($code, $ARGS, $numtests) = @_;
+    $code =~ s/(['\\])/\\$1/g;
+    return "todo($ARGS, $numtests);\n"
+           . "try { EVAL('$code') }"
+           . " // (flunk \"non-compiling test\" for ^$numtests);\n"
+}
+
 sub fudgeblock {
     while (<>) {
         if (/^\s*\#\?DOES[:\s] \s* (.*)/x) {
@@ -313,8 +321,9 @@ sub fudgeblock {
                 }
                 elsif ($FUDGE eq 'eval') {
                     chomp;
-                    s/(['\\])/\\$1/g;
-                    $_ = "try { EVAL('$_') } // skip($ARGS, $numtests);\n";
+                    $_ = wrap_eval($_, $ARGS, $numtests);
+                    #s/(['\\])/\\$1/g;
+                    #$_ = "try { EVAL('$_') } // skip($ARGS, $numtests);\n";
                 }
                 else {
                     warn "Don't know how to mark block for $FUDGE!\n";
@@ -356,8 +365,9 @@ sub fudgeblock {
                     $_ = "(try $_) // flunk($ARGS);\n";
                 }
                 elsif ($FUDGE eq 'eval') {
-                    s/(['\\])/\\$1/g;
-                    $_ = "EVAL('$_') // skip($ARGS, $numtests);\n";
+                    $_ = wrap_eval($_, $ARGS, $numtests);
+                    #s/(['\\])/\\$1/g;
+                    #$_ = "try { EVAL('$_') } // skip($ARGS, $numtests);\n";
                 }
                 else {
                     warn "Don't know how to mark statement for $FUDGE!\n";

--- a/fudge
+++ b/fudge
@@ -72,7 +72,8 @@ Usage: $0 [options] [implname] testfilename [fudgedtestfilename]
         comment out num tests or blocks and call skip(num)
 
     #?implname [num] eval 'reason'
-        eval num tests or blocks and skip(num) on parsefail
+        eval num tests or blocks and flunk() with todo(reason,num) if parse 
+        fails
 
     #?implname [num] try 'reason'
         try num tests or blocks and fail on exception

--- a/fudge
+++ b/fudge
@@ -314,7 +314,7 @@ sub fudgeblock {
                 elsif ($FUDGE eq 'eval') {
                     chomp;
                     s/(['\\])/\\$1/g;
-                    $_ = "EVAL('$_') // skip($ARGS, $numtests);\n";
+                    $_ = "try { EVAL('$_') } // skip($ARGS, $numtests);\n";
                 }
                 else {
                     warn "Don't know how to mark block for $FUDGE!\n";

--- a/packages/S11-modules/lib/GH2979.pm6
+++ b/packages/S11-modules/lib/GH2979.pm6
@@ -7,7 +7,7 @@ our $b;
 sub b { }
 
 multi EXPORT {
-    %(
+    Map.new(
         GH2979-Foo::EXPORT::ALL::,
         '@bar' => @b,
         '%bar' => %b,

--- a/packages/S11-modules/lib/OuterModule.pm6
+++ b/packages/S11-modules/lib/OuterModule.pm6
@@ -1,6 +1,6 @@
-unit module OuterModule;
 use v6;
+unit module OuterModule;
 
-use InnerModule :ALL :EXPORT;
+use InnerModule :ALL, :EXPORT;
 
 # vim: expandtab shiftwidth=4

--- a/spectest.data
+++ b/spectest.data
@@ -460,6 +460,7 @@ S05-modifier/Perl_6.t
 S05-modifier/Perl_7.t
 S05-modifier/Perl_8.t
 S05-modifier/Perl_9.t
+S05-modifier/exhaustive.t
 S05-modifier/continue.t
 S05-modifier/counted-match.t
 S05-modifier/counted.t

--- a/spectest.data
+++ b/spectest.data
@@ -953,6 +953,7 @@ S17-supply/tail.t
 S17-supply/throttle.t     # moar slow
 S17-supply/unique.t       # slow
 S17-supply/wait.t         # slow
+S17-supply/watch-path.t   # slow
 S17-supply/words.t
 S17-supply/zip-latest.t
 S17-supply/zip.t

--- a/spectest.data
+++ b/spectest.data
@@ -732,6 +732,7 @@ S13-syntax/aliasing.t
 S13-type-casting/methods.t
 S14-roles/anonymous.t
 S14-roles/attributes.t
+S14-roles/attributes-6e.t
 S14-roles/basic.t
 S14-roles/bool.t
 S14-roles/composition.t

--- a/spectest.data
+++ b/spectest.data
@@ -955,7 +955,6 @@ S17-supply/tail.t
 S17-supply/throttle.t     # moar slow
 S17-supply/unique.t       # slow
 S17-supply/wait.t         # slow
-S17-supply/watch-path.t   # slow
 S17-supply/words.t
 S17-supply/zip-latest.t
 S17-supply/zip.t

--- a/spectest.data
+++ b/spectest.data
@@ -960,16 +960,17 @@ S19-command-line/help.t
 S19-command-line/repl.t
 S22-package-format/local.t
 S24-testing/0-compile.t
+S24-testing/2-force_todo.t
+S24-testing/3-output.t
+S24-testing/7-bail_out.t
+S24-testing/8-die_on_fail.t
+S24-testing/9-is_deeply.t
 S24-testing/10-is-approx.t
 S24-testing/11-plan-skip-all-subtests.t
 S24-testing/11-plan-skip-all.t            # stress
 S24-testing/12-subtest-todo.t
 S24-testing/13-cmp-ok.t
 S24-testing/14-like-unlike.t
-S24-testing/3-output.t
-S24-testing/7-bail_out.t
-S24-testing/8-die_on_fail.t
-S24-testing/9-is_deeply.t
 S24-testing/fails-like.t
 S24-testing/line-numbers.t
 S26-documentation/01-delimited.t

--- a/spectest.data
+++ b/spectest.data
@@ -471,6 +471,7 @@ S05-modifier/ii.t
 S05-modifier/my.t
 S05-modifier/overlapping.t
 S05-modifier/pos.t
+S05-modifier/ratchet.t
 S05-modifier/repetition-exhaustive.t
 S05-modifier/repetition.t
 S05-modifier/samemark.t

--- a/spectest.data
+++ b/spectest.data
@@ -1072,6 +1072,7 @@ S32-io/IO-Socket-INET-UNIX.t # moar
 S32-io/IO-Socket-INET.t
 S32-io/chdir-process.t    # moar
 S32-io/chdir.t
+S32-io/child-secure.t
 S32-io/copy.t
 S32-io/dir.t
 S32-io/file-tests.t

--- a/spectest.data
+++ b/spectest.data
@@ -415,6 +415,7 @@ S05-interpolation/regex-in-variable.t
 S05-mass/charsets.t
 S05-mass/named-chars.t
 S05-mass/properties-block.t
+S05-mass/properties-contributory.t
 S05-mass/properties-derived.t
 S05-mass/properties-general.t
 S05-mass/properties-script.t

--- a/spectest.data
+++ b/spectest.data
@@ -349,6 +349,7 @@ S04-phasers/first.t
 S04-phasers/in-eval.t
 S04-phasers/in-loop.t
 S04-phasers/init.t
+S04-phasers/interpolate.t
 S04-phasers/keep-undo.t
 S04-phasers/multiple.t
 S04-phasers/next.t

--- a/spectest.data
+++ b/spectest.data
@@ -603,6 +603,7 @@ S09-typed-arrays/native-num.t
 S09-typed-arrays/native-str.t
 S09-typed-arrays/native.t
 S10-packages/basic.t
+S10-packages/export.t
 S10-packages/joined-namespaces.t
 S10-packages/precompilation.t # slow
 S10-packages/require-and-use.t

--- a/spectest.data
+++ b/spectest.data
@@ -755,6 +755,7 @@ S14-roles/stubs.t
 S14-roles/submethods-6e.t
 S14-roles/submethods.t
 S14-roles/typecheck.t
+S14-roles/versioning.t
 S14-traits/attributes.t
 S14-traits/routines.t
 S14-traits/variables.t

--- a/spectest.data
+++ b/spectest.data
@@ -294,6 +294,7 @@ S03-operators/value_equivalence.t
 S03-sequence/arity-2-or-more.t
 S03-sequence/arity0.t
 S03-sequence/basic.t
+S03-sequence/exhaustive.t
 S03-sequence/limit-arity-2-or-more.t
 S03-sequence/misc.t
 S03-sequence/nonnumeric.t

--- a/spectest.data
+++ b/spectest.data
@@ -1153,6 +1153,7 @@ S32-list/seq.t
 S32-list/skip.t
 S32-list/sort.t
 S32-list/squish.t
+S32-list/toggle.t
 S32-list/tail.t
 S32-list/unique.t
 S32-num/abs.t

--- a/spectest.data
+++ b/spectest.data
@@ -632,6 +632,7 @@ S11-modules/runtime.t
 S11-repository/cur-candidates.t
 S11-repository/cur-current-distribution.t
 S11-repository/curli-install.t
+S12-attributes/augment-and-initialization.t
 S12-attributes/class.t
 S12-attributes/clone.t
 S12-attributes/defaults.t

--- a/spectest.data
+++ b/spectest.data
@@ -634,6 +634,7 @@ S11-modules/nested.t
 S11-modules/perl6lib.t
 S11-modules/require.t
 S11-modules/runtime.t
+S11-modules/versioning.t
 S11-repository/cur-candidates.t
 S11-repository/cur-current-distribution.t
 S11-repository/curli-install.t

--- a/spectest.data
+++ b/spectest.data
@@ -484,6 +484,7 @@ S05-transliteration/trans-TR-operator.t
 S05-transliteration/trans-tr-lowercase-operator.t
 S05-transliteration/trans.t
 S05-transliteration/with-closure.t
+S06-advanced/dispatching.t
 S06-advanced/callframe.t
 S06-advanced/callsame.t
 # TODO S06-advanced/dispatching.t

--- a/spectest.data
+++ b/spectest.data
@@ -1218,6 +1218,7 @@ S32-str/rindex.t
 S32-str/samecase.t
 S32-str/samemark.t
 S32-str/shiftjis-encode-decode.t # moar
+S32-str/space-chars.t
 S32-str/split-simple.t
 S32-str/split.t
 S32-str/sprintf-b.t

--- a/spectest.data
+++ b/spectest.data
@@ -998,6 +998,7 @@ S26-documentation/07c-tables.t
 S26-documentation/08-formattingcodes.t
 S26-documentation/09-configuration.t
 S26-documentation/10-doc-cli.t
+S26-documentation/12-non-breaking-space.t
 S26-documentation/14-defn.t
 S26-documentation/15-numbered-alias.t
 S26-documentation/block-leading-user-format.t

--- a/spectest.data
+++ b/spectest.data
@@ -374,6 +374,7 @@ S04-statements/given.t
 S04-statements/if.t
 S04-statements/label.t
 S04-statements/last.t
+S04-statements/leave.t
 S04-statements/loop.t
 S04-statements/map-and-sort-in-for.t
 S04-statements/next.t

--- a/spectest.data
+++ b/spectest.data
@@ -750,6 +750,7 @@ S14-roles/submethods.t
 S14-roles/typecheck.t
 S14-traits/attributes.t
 S14-traits/routines.t
+S14-traits/variables.t
 S15-literals/identifiers.t
 S15-literals/numbers.t
 S15-nfg/GraphemeBreakTest.t     # moar

--- a/spectest.data
+++ b/spectest.data
@@ -484,10 +484,9 @@ S05-transliteration/trans-TR-operator.t
 S05-transliteration/trans-tr-lowercase-operator.t
 S05-transliteration/trans.t
 S05-transliteration/with-closure.t
-S06-advanced/dispatching.t
 S06-advanced/callframe.t
 S06-advanced/callsame.t
-# TODO S06-advanced/dispatching.t
+S06-advanced/dispatching.t
 S06-advanced/lexical-subs.t
 S06-advanced/recurse.t
 S06-advanced/return.t
@@ -854,6 +853,7 @@ S16-io/supply.t
 S16-io/tmpdir.t
 S16-io/watch.t
 S16-io/words.t
+S16-unfiled/getpeername.t
 S16-unfiled/rebindstdhandles.t
 S17-channel/basic.t
 S17-channel/stress.t     # stress slow

--- a/spectest.data
+++ b/spectest.data
@@ -608,6 +608,7 @@ S10-packages/joined-namespaces.t
 S10-packages/nested-use.t 
 S10-packages/precompilation.t # slow
 S10-packages/require-and-use.t
+S10-packages/scope.t
 S10-packages/use-with-class.t
 S11-compunit/compunit-dependencyspecification.t
 S11-compunit/compunit-repository.t

--- a/spectest.data
+++ b/spectest.data
@@ -605,6 +605,7 @@ S09-typed-arrays/native.t
 S10-packages/basic.t
 S10-packages/export.t
 S10-packages/joined-namespaces.t
+S10-packages/nested-use.t 
 S10-packages/precompilation.t # slow
 S10-packages/require-and-use.t
 S10-packages/use-with-class.t

--- a/spectest.data
+++ b/spectest.data
@@ -374,6 +374,7 @@ S04-statements/given.t
 S04-statements/if.t
 S04-statements/label.t
 S04-statements/last.t
+S04-statements/lazy.t
 S04-statements/leave.t
 S04-statements/loop.t
 S04-statements/map-and-sort-in-for.t

--- a/spectest.data
+++ b/spectest.data
@@ -721,6 +721,7 @@ S12-subset/subtypes.t
 S13-overloading/metaoperators.t
 S13-overloading/operators.t
 S13-overloading/typecasting-long.t
+S13-syntax/aliasing.t
 S13-type-casting/methods.t
 S14-roles/anonymous.t
 S14-roles/attributes.t

--- a/spectest.data
+++ b/spectest.data
@@ -934,6 +934,7 @@ S17-supply/reverse.t
 S17-supply/rotate.t
 S17-supply/rotor.t
 S17-supply/schedule-on.t
+S17-supply/Seq.t
 S17-supply/skip.t
 S17-supply/sort.t
 S17-supply/split.t

--- a/spectest.data
+++ b/spectest.data
@@ -616,6 +616,7 @@ S11-compunit/compunit-dependencyspecification.t
 S11-compunit/compunit-repository.t
 S11-compunit/rt126904.t
 S11-modules/export.t
+S11-modules/gh2979.t
 S11-modules/import-multi.t
 S11-modules/import-tag.t
 S11-modules/import.t


### PR DESCRIPTION
In elaboration of #657 

Aside from evaluating and fixing the tests, this PR introduces a slight change to `fudge` by extending the `eval` verb functionality to suppress `EVAL`-thrown exceptions and produce as many `flunk` as necessary if `EVAL` fails. All this done under `todo` to make harness report _TODO passed_ if the evaled tests are passing.