### PR TITLE
Rosettacode comment updates

### DIFF
--- a/rosettacode/greatest_element_of_a_list.t
+++ b/rosettacode/greatest_element_of_a_list.t
@@ -1,4 +1,4 @@
-# http://rosettacode.org/wiki/Greatest_element_of_a_list#Perl_6
+# http://rosettacode.org/wiki/Greatest_element_of_a_list#Raku
 
 use v6;
 use Test;

--- a/rosettacode/sierpinski_triangle.t
+++ b/rosettacode/sierpinski_triangle.t
@@ -1,4 +1,4 @@
-# http://rosettacode.org/wiki/Sierpinski_triangle#Perl_6
+# http://rosettacode.org/wiki/Sierpinski_triangle#Raku
 
 use v6;
 use Test;


### PR DESCRIPTION
The comments of the two rosettacode tests updated to refer to the (updated on their end) “#Raku” url anchor.