### PR TITLE
Test FIRST statement in loop does not warn

### DIFF
--- a/S04-phasers/in-loop.t
+++ b/S04-phasers/in-loop.t
@@ -1,8 +1,9 @@
 use v6;
 
 use Test;
+use Test::Util;
 
-plan 20;
+plan 21;
 
 # TODO, based on synopsis 4:
 #
@@ -229,4 +230,15 @@ subtest 'FIRST+LAST loops as last statement in subs work and do not crash' => {
         is-deeply ($a, $b, $c), (1, 1, 100), 'wanted loop';
     }
 }
+
+# https://github.com/rakudo/rakudo/issues/1900
+{
+    doesn't-warn {
+        loop {
+            FIRST 'Here';
+            last;
+        }
+    }, 'FIRST statement in loop does not warn';
+}
+
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
Closes R#1900 rakudo/rakudo#1900

For comparison:

```
$ perl6 --version
This is Rakudo version 2018.05 built on MoarVM version 2018.05
implementing Perl 6.c.
$ perl6 -Ipackages/Test-Helpers/lib S04-phasers/in-loop.t 2>&1 | grep LOOP
Useless use of LOOP_BLOCK_3 symbol in sink context (line 237)
```

```
$ raku --version
This is Rakudo version 2020.07 built on MoarVM version 2020.07
implementing Raku 6.d.
$ raku -Ipackages/Test-Helpers/lib S04-phasers/in-loop.t 2>&1 | grep LOOP | wc -l
0
```

Note that, annoyingly, the test _also_ passes in 2018.05 because in that version for some reason Test::Util's  `doesn't-warn` doesn't seem to work as expected.