### PR TITLE
Add tests for nominalizables

### DIFF
--- a/S02-types/nominalizables.t
+++ b/S02-types/nominalizables.t
@@ -1,0 +1,49 @@
+use Test;
+# Test for different combinations of nominalizable types.
+
+plan 2;
+
+# https://github.com/rakudo/rakudo/issues/2446
+subtest "Subset of a coercion", {
+    plan 4;
+    subset OfCoercion of Int();
+    my OfCoercion $v = 1;
+    $v = "42";
+    isa-ok $v, Int, "variable of subset type has the right type";
+    is $v, 42, "the variable got the right value";
+
+    sub foo(OfCoercion $p) {
+        isa-ok $p, Int, "function parameter of subset type has the right type";
+        is $p, 13, "the parameter got the right value";
+    }
+    foo("13");
+}
+
+# https://github.com/rakudo/rakudo/issues/2427
+subtest "Nested coercers", {
+    plan 5;
+    class Source {
+        method Num { pi }
+        method Rat { 3.1415926 }
+        method Str { die "Can't coerce into Str" }
+    }
+
+    throws-like { my Str(Source) $e = Source.new; }, X::AdHoc,
+        "control: direct coercion fails as expected";
+
+    my Str(Num(Source)) $v;
+
+    throws-like { $v = 42 }, X::TypeCheck::Assignment,
+        "assignment of unacceptable value to a variable fails";
+
+    $v = e;
+    is $v, e.Str, "a chained coercion accepts an intermidiate target type";
+
+    $v = Source.new;
+    is $v, "3.141592653589793", "nested coercions work for a scalar";
+
+    sub foo(Str(Rat(Source)) $p) {
+        is $p, "3.1415926", "nested coercions work for function parameters";
+    }
+    foo(Source.new);
+}

--- a/spectest.data
+++ b/spectest.data
@@ -174,6 +174,7 @@ S02-types/native.t
 S02-types/nested_arrays.t
 S02-types/nested_pairs.t
 S02-types/nil.t
+S02-types/nominalizables.t
 S02-types/num.t
 S02-types/pair.t
 S02-types/parsing-bool.t


### PR DESCRIPTION
Test for subsetting a coercion and nested coercers.

In support of rakudo/rakudo#4058