### PR TITLE
Make test conform to the new coercion semantics and role invocation

### DIFF
--- a/S02-literals/allomorphic.t
+++ b/S02-literals/allomorphic.t
@@ -458,6 +458,6 @@ group-of 4 => '.comb on allomorphs uses Str variant' => {
 }
 
 # https://github.com/rakudo/rakudo/issues/3308
-is Str($*USER).^name, "Str", 'No leaking of guts types when coercing allomorph to Str';
+isa-ok Str($*USER), Str, 'No leaking of guts types when coercing allomorph to Str';
 
 # vim: expandtab shiftwidth=4

--- a/integration/weird-errors.t
+++ b/integration/weird-errors.t
@@ -224,10 +224,16 @@ eval-lives-ok '[;0]', '[;0] does not explode the compiler';
 }
 
 # https://github.com/Raku/old-issue-tracker/issues/2879
-throws-like ｢class A114672 {}; class B114672 is A114672 { has $!x = 5; ｣
-    ~ ｢our method foo(A114672:) { say $!x } }; &B::foo(A.new)｣,
+throws-like q:to/CODE_END/,
+            class A114672 {};
+            class B114672 is A114672 {
+                has $!x = 5;
+                our method foo(A114672:) { say $!x }
+            };
+            &B114672::foo(A114672.new)
+            CODE_END
     Exception,
-'no segfault';
+    'no segfault';
 
 {
     # Purpose of the test is to check that despite having a race


### PR DESCRIPTION
In support of rakudo/rakudo#4096. Previously the invocation handler was unconditionally using a coercion method named after the target type. Now it uses the new coercion protocol. With this change `Str($*USER)` ends up as `IntStr` because no actual coercion is needed. Correspondingly, testing for the outcome of it to be a `Str` class makes more sense than to test for it to be exactly a `Str` instance.