### PR TITLE
Import `bsd_glob` from File::Glob, not the tag `:bsd_glob`.

### DIFF
--- a/fudgeall
+++ b/fudgeall
@@ -2,7 +2,7 @@
 
 use strict;
 use warnings;
-use File::Glob ':bsd_glob';
+use File::Glob 'bsd_glob';
 
 my @opts;
 while( $_ = $ARGV[0], /^-/ ) {


### PR DESCRIPTION
The latter is only available in Perl v5.16 (and later), and is a compile
time failure on earlier Perls. However, we don't *need* the tag - its
purpose is to *override* CORE::glob with `bsd_glob`. As we make a direct
call to `bsd_glob` we only need to import *that*, which works all the way
back to v5.6.0 or so.

With this change fudgeall works with system Perl on Solaris 5.11, which is
v5.12.5.