### PR TITLE
Add tests for nested array slices

### DIFF
--- a/S09-subscript/slice.t
+++ b/S09-subscript/slice.t
@@ -143,7 +143,7 @@ subtest 'infinite ranges and whatever stars' => {
 
 # https://github.com/Raku/old-issue-tracker/issues/6233
 subtest 'nested slices' => {
-    plan 44;
+    plan 62;
     is-deeply ("a".."z")[(3, (4, (5,)))],      ("d", ("e", ("f",))),                 'Nested slice, no adverbs';
     is-deeply ("a".."z")[(3, (30, (5,)))]:p,   (3 => "d", ((5 => "f",),)),           'Nested slice, p adverb';
     is-deeply ("a".."z")[(3, (30, (5,)))]:!p,  (3 => "d", (30 => Nil, (5 => "f",))), 'Nested slice, negated p adverb';
@@ -167,81 +167,99 @@ subtest 'nested slices' => {
     is @a, ("a", "b", "c", Any, "e"),                            'Nested slice, delete adverb 2-2';
 
     @a = ("a", "b", "c", "d", "e", "f");
-    is-deeply @a[(3, (30, (5,)))]:!delete, ("d", (Any, ("f",))), 'Nested slice, delete adverb 3-1';
-    is @a, ("a", "b", "c", "d", "e", "f"),                       'Nested slice, delete adverb 3-2';
+    is-deeply @a[(3, (30, (5,)))]:!delete, ("d", (Any, ("f",))), 'Nested slice, negated delete adverb 3-1';
+    is @a, ("a", "b", "c", "d", "e", "f"),                       'Nested slice, negated delete adverb 3-2';
 
     # multiple adverbs
     # :delete :kv            delete, return key/values of actually deleted keys
     @a = ("a", "b", "c", "d", "e", "f");
     is-deeply @a[(3, (30, (5,)))]:delete:kv, (3, "d", ((5, "f"),)),                             'Nested slice, delete + kv adverbs';
+    is @a, ("a", "b", "c", Any, "e"),                                                           'Nested slice, delete + kv adverbs 2';
 
     # :delete :!kv           delete, return key/values of all keys attempted
     @a = ("a", "b", "c", "d", "e", "f");
     is-deeply @a[(3, (30, (5,)))]:delete:!kv, (3, "d", (30, Any, (5, "f"))),                    'Nested slice, delete + !kv adverbs';
+    is @a, ("a", "b", "c", Any, "e"),                                                           'Nested slice, delete + !kv adverbs 2';
 
     # :delete :p             delete, return pairs of actually deleted keys
     @a = ("a", "b", "c", "d", "e", "f");
     is-deeply @a[(3, (30, (5,)))]:delete:p, (3 => "d", ((5 => "f",),)),                         'Nested slice, delete + p adverbs';
+    is @a, ("a", "b", "c", Any, "e"),                                                           'Nested slice, delete + p adverbs 2';
 
     # :delete :!p            delete, return pairs of all keys attempted
     @a = ("a", "b", "c", "d", "e", "f");
     is-deeply @a[(3, (30, (5,)))]:delete:!p, (3 => "d", (30 => Any, (5 => "f",))),              'Nested slice, delete + !p adverbs';
+    is @a, ("a", "b", "c", Any, "e"),                                                           'Nested slice, delete + !p adverbs 2';
 
     # :delete :k             delete, return actually deleted keys
     @a = ("a", "b", "c", "d", "e", "f");
     is-deeply @a[(3, (30, (5,)))]:delete:k, (3, ((5,),)),                                       'Nested slice, delete + k adverbs';
+    is @a, ("a", "b", "c", Any, "e"),                                                           'Nested slice, delete + k adverbs 2';
 
     # :delete :!k            delete, return all keys attempted to delete
     @a = ("a", "b", "c", "d", "e", "f");
     is-deeply @a[(3, (30, (5,)))]:delete:!k, (3, (30, (5,))),                                   'Nested slice, delete + !k adverbs';
+    is @a, ("a", "b", "c", Any, "e"),                                                           'Nested slice, delete + !k adverbs 2';
 
     # :delete :v             delete, return values of actually deleted keys
     @a = ("a", "b", "c", "d", "e", "f");
     is-deeply @a[(3, (30, (5,)))]:delete:v, ("d", (("f",),)),                                   'Nested slice, delete + v adverbs';
+    is @a, ("a", "b", "c", Any, "e"),                                                           'Nested slice, delete + v adverbs 2';
 
     # :delete :!v            delete, return values of all keys attempted
     @a = ("a", "b", "c", "d", "e", "f");
     is-deeply @a[(3, (30, (5,)))]:delete:!v, ("d", (Any, ("f",))),                              'Nested slice, delete + !v adverbs';
+    is @a, ("a", "b", "c", Any, "e"),                                                           'Nested slice, delete + !v adverbs 2';
 
     # :delete :exists        delete, return Bools indicating keys existed
     @a = ("a", "b", "c", "d", "e", "f");
     is-deeply @a[(3, (30, (5,)))]:delete:exists, (True, (False, (True,))),                      'Nested slice, delete + exists adverbs';
+    is @a, ("a", "b", "c", Any, "e"),                                                           'Nested slice, delete + exists adverbs 2';
 
     # :delete :!exists       delete, return Bools indicating keys did not exist
     @a = ("a", "b", "c", "d", "e", "f");
     is-deeply @a[(3, (30, (5,)))]:delete:!exists, (False, (True, (False,))),                    'Nested slice, delete + !exists adverbs';
+    is @a, ("a", "b", "c", Any, "e"),                                                           'Nested slice, delete + !exists adverbs 2';
 
     # :delete :exists :kv    delete, return list with key,True for key existed
     @a = ("a", "b", "c", "d", "e", "f");
     is-deeply @a[(3, (30, (5,)))]:delete:exists:kv, (3, True, ((5, True),)),                    'Nested slice, delete + exists + kv adverbs';
+    is @a, ("a", "b", "c", Any, "e"),                                                           'Nested slice, delete + exists + kv adverbs 2';
 
     # :delete :!exists :kv   delete, return list with key,False for key existed
     @a = ("a", "b", "c", "d", "e", "f");
     is-deeply @a[(3, (30, (5,)))]:delete:!exists:kv, (3, False, ((5, False),)),                 'Nested slice, delete + !exists + kv adverbs';
+    is @a, ("a", "b", "c", Any, "e"),                                                           'Nested slice, delete + !exists + kv adverbs 2';
 
     # :delete :exists :!kv   delete, return list with key,Bool whether key existed
     @a = ("a", "b", "c", "d", "e", "f");
     is-deeply @a[(3, (30, (5,)))]:delete:exists:!kv, (3, Bool::True, (30, False, (5, True))),   'Nested slice, delete + exists + !kv adverbs';
+    is @a, ("a", "b", "c", Any, "e"),                                                           'Nested slice, delete + exists + !kv adverbs 2';
 
     # :delete :!exists :!kv  delete, return list with key,!Bool whether key existed
     @a = ("a", "b", "c", "d", "e", "f");
     is-deeply @a[(3, (30, (5,)))]:delete:!exists:!kv, (3, False, (30, True, (5, False))),       'Nested slice, delete + !exists + !kv adverbs';
+    is @a, ("a", "b", "c", Any, "e"),                                                           'Nested slice, delete + !exists + !kv adverbs 2';
 
     # :delete :exists :p     delete, return pairs with key/True for key existed
     @a = ("a", "b", "c", "d", "e", "f");
     is-deeply @a[(3, (30, (5,)))]:delete:exists:p, (3 => True, ((5 => True,),)),                'Nested slice, delete + exists + p adverbs';
+    is @a, ("a", "b", "c", Any, "e"),                                                           'Nested slice, delete + exists + p adverbs 2';
 
     # :delete :!exists :p    delete, return pairs with key/False for key existed
     @a = ("a", "b", "c", "d", "e", "f");
     is-deeply @a[(3, (30, (5,)))]:delete:!exists:p, (3 => False, ((5 => False,),)),             'Nested slice, delete + !exists + p adverbs';
+    is @a, ("a", "b", "c", Any, "e"),                                                           'Nested slice, delete + !exists + p adverbs 2';
 
     # :delete :exists :!p    delete, return pairs with key/Bool whether key existed
     @a = ("a", "b", "c", "d", "e", "f");
     is-deeply @a[(3, (30, (5,)))]:delete:exists:!p, (3 => True, (30 => False, (5 => True,))),   'Nested slice, delete + exists + !p adverbs';
+    is @a, ("a", "b", "c", Any, "e"),                                                           'Nested slice, delete + exists + !p adverbs 2';
 
     # :delete :!exists :!p   delete, return pairs with key/!Bool whether key existed
     @a = ("a", "b", "c", "d", "e", "f");
     is-deeply @a[(3, (30, (5,)))]:delete:!exists:!p, (3 => False, (30 => True, (5 => False,))), 'Nested slice, delete + !exists + !p adverbs';
+    is @a, ("a", "b", "c", Any, "e"),                                                           'Nested slice, delete + !exists + !p adverbs 2';
 
     # :exists :kv            return pairs with key,True for key exists
     @a = ("a", "b", "c", "d", "e", "f");

--- a/S09-subscript/slice.t
+++ b/S09-subscript/slice.t
@@ -10,7 +10,7 @@ Testing array slices.
 
 =end pod
 
-plan 34;
+plan 35;
 
 {   my @array = (3,7,9,11);
 
@@ -139,6 +139,16 @@ subtest 'infinite ranges and whatever stars' => {
     is-deeply (^3)[0 ..^ *],         (0, 1, 2), 'Whatever range exclusive';
     is        (^3)[*-1],             2,         'Whatever callable';
     is        (^3)[{ $^elems - 1 }], 2,         'Callable';
+}
+
+# https://github.com/Raku/old-issue-tracker/issues/6233
+subtest 'nested slices' => {
+    plan 5;
+    is-deeply ("a".."z")[(3, (4, (5,)))],    ("d", ("e", ("f",))),                'Nested slice, no adverbs';
+    is-deeply ("a".."z")[(3, (4, (5,)))]:p,  (3 => "d", (4 => "e", (5 => "f",))), 'Nested slice, p adverb';
+    is-deeply ("a".."z")[(3, (4, (5,)))]:k,  (3, (4, (5,))),                      'Nested slice, k adverb';
+    is-deeply ("a".."z")[(3, (4, (5,)))]:v,  ("d", ("e", ("f",))),                'Nested slice, v adverb';
+    is-deeply ("a".."z")[(3, (4, (5,)))]:kv, (3, "d", (4, "e", (5, "f"))),        'Nested slice, kv adverb';
 }
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
It turns out that nested array slices were broken, i.e. using them
returned the wrong results.
This was reported in https://github.com/Raku/old-issue-tracker/issues/6233
During lizmat++ work to improve array slices it also turned out
that there were no tests in roast for the above reported issue.
This PR rectifies this omission.