### PR TITLE
Mark utf32 tests as todo for rakudo.moar

### DIFF
--- a/S32-encoding/registry.t
+++ b/S32-encoding/registry.t
@@ -2,18 +2,22 @@ use Test;
 use lib $?FILE.IO.parent(2).add: 'packages/Test-Helpers';
 use Test::Util;
 
-plan 40;
+#!rakudo.moar emit plan 40;
+#?rakudo.moar emit plan 37;
 
 for <utf8  utf-8  UTF-8 ascii  iso-8859-1  latin-1 utf16 utf-16 UTF-16 UTF16
      utf16le utf-16le utf16-le utf-16-le utf16be UTF16BE UTF-16be utf16-be
      utf-16-be utf16-le UTF16-BE UTF16-LE windows932 windows-932 windows-1251
      windows1251 windows-1252 windows1252 utf32 utf-32 UTF32> -> $name {
-    group-of 3 => "Can find built-in $name encoding" => {
-        given Encoding::Registry.find: $name {
+    #?rakudo.moar emit next if $name eq 'utf32' | 'utf-32' | 'UTF32';
+    # utf-32 encoding/decoding is NYI on rakudo.moarvm.  See MoarVM#1348 & rakudo#3293
+    group-of 4 => "Can find built-in $name encoding" => {
+        given try Encoding::Registry.find: $name {
             isa-ok  $_, Encoding::Builtin, 'type of result';
             does-ok $_, Encoding, 'does Encoding role';
             is (.alternative-names, .name).flat».fc.any, $name.fc,
                 'found right encoding';
+            lives-ok { .encoder.encode-chars('foo') }, 'can use encoding';
         }
     }
 }


### PR DESCRIPTION
Rakudo.moar was previously passing a test for utf32 support despite not actually supporting utf32.  This updates the test to more
reliably test for utf32 support and marks the test as todo for the MoarVM backend.

Without this change, rakudo/rakudo#4232 fails Roast spectests.

Related issues:  rakudo/rakudo#3293 and MoarVM/MoarVM#1348