### PR TITLE
Test using custom registries with encode & decode

### DIFF
--- a/S32-encoding/registry.t
+++ b/S32-encoding/registry.t
@@ -2,8 +2,8 @@ use Test;
 use lib $?FILE.IO.parent(2).add: 'packages/Test-Helpers';
 use Test::Util;
 
-#!rakudo.moar emit plan 40;
-#?rakudo.moar emit plan 37;
+#!rakudo.moar emit plan 42;
+#?rakudo.moar emit plan 39;
 
 for <utf8  utf-8  UTF-8 ascii  iso-8859-1  latin-1 utf16 utf-16 UTF-16 UTF16
      utf16le utf-16le utf16-le utf-16-le utf16be UTF16BE UTF-16be utf16-be
@@ -75,6 +75,23 @@ throws-like { Encoding::Registry.find('utf-29') },
     }
     is-deeply Encoding::Registry.register(NoAlternativeNamesEncoding), Nil,
         "Encodings with no alternative names method can be registered";
+}
+
+{
+    my class TestEncoding4 does Encoding {
+        method name()             { 'userspace-encoding' }
+        method encoder(*%options) { Encoding::Encoder::Builtin.new('utf8', blob8, |%options) }
+        method decoder(*%options) { Encoding::Decoder::Builtin.new('utf8', |%options) }
+    }
+    Encoding::Registry.register(TestEncoding4);
+    is-deeply "Hello, world!".encode('userspace-encoding'),
+              Blob[uint8].new(72,101,108,108,111,44,32,119,111,114,108,100,33),
+              'Regesterd encodings can be used to encode a Str';
+
+    is-deeply Blob[uint8].new(72,101,108,108,111,44,32,119,111,114,108,100,33)
+                         .decode('userspace-encoding'),
+              "Hello, world!",
+              'Regesterd encodings can be used to decode a Blob';
 }
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
(a cleaned up copy of #719 without merge conflicts.  I should have used a separate branch to begin with; sorry for the noise)

Tests that a user-defined encoding can be used with `String.encode` and with `Blob.decode`.  The former functionality is already supported by Rakudo, while the later is to be added in rakudo/rakudo#4231