### PR TITLE
Use $*KERNEL instead of $*DISTRO.name to skip tests on "OS X"/"macOS".

### DIFF
--- a/S32-str/utf8-c8.t
+++ b/S32-str/utf8-c8.t
@@ -188,7 +188,8 @@ if $*DISTRO.is-win {
     skip('Not clear if there is an alternative to this issue on Windows', 4);
 } elsif $*DISTRO.name eq 'browser' {
     skip('We don\'t have directories in the browser', 4);
-} elsif $*DISTRO.name eq 'macosx' {
+} elsif $*KERNEL eq 'darwin' {
+    # currently $*DISTRO.name is 'macosx' on OS X, 'macos' on macOS
     skip('Some problems on MacOS', 4);
 } else {
     my $test-dir = make-temp-dir;


### PR DESCRIPTION
The test needs to skip on Apple's file systems.

The value of $*KERNEL is consistent across releases, whereas what
$*DISTRO.name reports has changed from "macosx" to "macos" with Apple's
rebranding.