### PR TITLE
Improve test for subtest output

### DIFF
--- a/S24-testing/3-output.t
+++ b/S24-testing/3-output.t
@@ -51,8 +51,24 @@ is_run ｢
         ok 1, "foo\nbar";
         subtest "meow" => { ok 1, "mass\nbass\nmiss\nbiss" }
     ｣,
-    { :err(''), :0status,  :out("1..2\nok 1 - foo\n# bar\n    ok 1 - mass\n"
-        ~ "    # bass\n    # miss\n    # biss\n    1..1\nok 2 - meow\n") },
+    {
+        :err(''),
+        :status(0),
+        :out(/
+            "1..2\n"
+            "ok 1 - foo\n"
+            "# bar\n"
+            "# Subtest: meow\n"
+            # The particular width of indentation is not relevant but must be no less than 1 whitespace and be
+            # consistent across all lines of subtest output.
+            $<indent>=[\s+] "ok 1 - mass\n"
+            $<indent> "# bass\n"
+            $<indent> "# miss\n"
+            $<indent> "# biss\n"
+            $<indent> "1..1\n"
+            "ok 2 - meow\n"
+        /),
+    },
 'descriptions with newlines get escaped from TAP with `#` at start of line';
 
 # https://irclog.perlgeek.de/perl6/2017-08-18#i_15038473


### PR DESCRIPTION
Take into account additional header from a subtest output which reports
subtest message and looks like:

   # Subtest: message

Also improve testing for indented lines. If we ever decide to change the
number of spaces in subtest indentation then we won't need to change the
test. It now allows any number of spaces but only ensures the number
doesn't change across subtest output.

Support for rakudo/rakudo#4280 and rakudo/rakudo#4266