### PR TITLE
Add tests for hyper/race throwing on second .iterator

### DIFF
--- a/S07-hyperrace/basics.t
+++ b/S07-hyperrace/basics.t
@@ -189,9 +189,8 @@ is-deeply ^1000 .hyper.map(*+1).Array, [^1000 + 1], '.hyper preserves order';
 }
 
 # https://github.com/Raku/old-issue-tracker/issues/5261
-#?rakudo skip 'reliably hangs / segfaults on at least MacOS'
 {
-    is-deeply (^100).race(batch=>1).map({ sprintf '%1$s %2$s', 5, 42 }).List, ‘5 42’ xx 100, 
+    is-deeply (^100).race(batch=>1).map({ sprintf '%s %s', 5, 42 }).List, ‘5 42’ xx 100,
         'sprintf is threadsafe when format tokens use explicit indices';
 }
 

--- a/S07-hyperrace/basics.t
+++ b/S07-hyperrace/basics.t
@@ -1,7 +1,7 @@
 use v6;
 use Test;
 
-plan 87;
+plan 89;
 
 for <hyper race> -> $meth {
         sub hr (\seq) { $meth eq 'race' ?? seq.sort !! seq }
@@ -49,7 +49,7 @@ for <hyper race> -> $meth {
         }
 
         # https://github.com/Raku/old-issue-tracker/issues/5008
-        
+
         for <batch degree> -> $name {
             for (-1,0) -> $value {
                 throws-like { (^10)."$meth"(|($name => $value)) },
@@ -59,7 +59,7 @@ for <hyper race> -> $meth {
         }
 
         # https://github.com/Raku/old-issue-tracker/issues/5651
-        
+
         dies-ok { for (1..1)."$meth"() { die } },
             "Exception thrown in $meth for is not lost (1..1)";
         dies-ok { for (1..1000)."$meth"() { die } },
@@ -74,7 +74,7 @@ for <hyper race> -> $meth {
             "Exception thrown in $meth grep is not lost (1..1000)";
 
         # https://github.com/Raku/old-issue-tracker/issues/5111
-        
+
         subtest ".$meth with .map that sleep()s" => {
             plan 10;
 
@@ -90,7 +90,7 @@ for <hyper race> -> $meth {
         }
 
         # https://github.com/Raku/old-issue-tracker/issues/5301
-        
+
         {
             multi sub f { $^a² }
             is-deeply (^10)."$meth"().map(&f).&hr.List,
@@ -99,7 +99,7 @@ for <hyper race> -> $meth {
         }
 
         # https://github.com/Raku/old-issue-tracker/issues/6435
-        
+
         {
             my atomicint $got = 0;
             for <a b c>."$meth"() { $got⚛++ }
@@ -107,7 +107,7 @@ for <hyper race> -> $meth {
         }
 
         # https://github.com/Raku/old-issue-tracker/issues/5994
-        
+
         is-deeply ([+] (1..100)."$meth"()), 5050,
             "Correct result for [+] (1..100).$meth";
         is-deeply ([+] (1..100)."$meth"().grep(* != 22)), 5028,
@@ -213,4 +213,16 @@ is-deeply ^1000 .hyper.map(*+1).Array, [^1000 + 1], '.hyper preserves order';
         'die in a hyper nested in a hyper propagates exception';
 }
 
+# https://github.com/rakudo/rakudo/issues/4413
+{
+    throws-like
+        { (.iterator, .iterator) given (^10).hyper },
+        X::Seq::Consumed,
+        "can only have single iterator per hyper";
+
+    throws-like
+        { (.iterator, .iterator) given (^10).race },
+        X::Seq::Consumed,
+        "can only have single iterator per race";
+}
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
`HyperSeq` and `RaceSeq` should throw if an iterator has been already
produced for them, similar to what `Seq` currently does.

In support of rakudo/rakudo#4416 and rakudo/rakudo#4413