### PR TITLE
Align test #28 of S26-documentation/02-paragraph.t with intended design of E<>

### DIFF
--- a/S26-documentation/02-paragraph.t
+++ b/S26-documentation/02-paragraph.t
@@ -116,6 +116,7 @@ is $r.contents[4].contents[0].contents, "Turn into Jelly Beans!",
 
 
 # https://github.com/Raku/old-issue-tracker/issues/6293
+#?rakudo.jvm skip 'GH Raku/nqp#727'
 is_run Q:to/♥♥♥/, :compiler-args['--doc=Text'],
     =for pod
     =for nested

--- a/S26-documentation/02-paragraph.t
+++ b/S26-documentation/02-paragraph.t
@@ -120,8 +120,8 @@ is_run Q:to/♥♥♥/, :compiler-args['--doc=Text'],
     =for pod
     =for nested
     =for para :nested(1)
-    E<a;b>E<a;b;c>
+    E<alpha;beta>E<alpha;beta;gamma>
     ♥♥♥
-{:err(''), :out("ababc\n"), :0status}, 'nested paras do not crash/warn';
+{:err(''), :out("αβαβγ\n"), :0status}, 'nested paras do not crash/warn';
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
Lowercase strings in E<> should be valid HTML5 entities. The corrected test will fail without the corresponding Rakudo PR, so please merge rakudo/rakudo#4427 at the same time as this one. The fix could not be easily implemented for JVM due to Raku/nqp#727, so this also fudges the test under JVM