### PR TITLE
Add tests for type constraints on forwarded, constrained generics

### DIFF
--- a/S14-roles/generic-subtyping.t
+++ b/S14-roles/generic-subtyping.t
@@ -1,0 +1,24 @@
+use v6;
+
+use Test;
+
+plan 5;
+
+lives-ok({ EVAL(Q:to/ROLES/) }, 'can do subtyped generic roles');
+role R1[Any ::T] { }
+role R2[Cool ::T] does R1[T] { }
+ROLES
+
+EVAL(Q:to/TESTS/);
+ok(R2[Cool] ~~ R1[Any],  'subtyped generic roles');
+ok(R2[Cool] ~~ R2[Cool], 'subtyped generic roles');
+ok(R2[Int] ~~ R2[Cool],  'subtyped generic roles');
+TESTS
+
+lives-ok({ EVAL(Q:to/ROLE/) }, 'can lookup roles of subtyped generic roles done by roles before they get composed');
+multi sub trait_mod:<is>(Mu:U \T, :ok($)!) { T.^roles[0].^roles }
+
+role R2[Int ::T] does R1[T] is ok { }
+ROLE
+
+# vim: expandtab shiftwidth=4

--- a/spectest.data
+++ b/spectest.data
@@ -760,6 +760,7 @@ S14-roles/parameter-subtyping.t
 S14-roles/parameterized-basic.t
 S14-roles/parameterized-mixin.t
 S14-roles/parameterized-type.t
+S14-roles/generic-subtyping.t
 S14-roles/rw.t
 S14-roles/stubs.t
 S14-roles/submethods-6e.t


### PR DESCRIPTION
The bug WRT the `roles` metamethod does not appear to be possible to trigger without invoking it directly because the `$transitive` flag is set to `0` in noteworthy exposed metamethods that depend on it.

See https://github.com/rakudo/rakudo/pull/4436