### PR TITLE
Use more correct approach in list EVAL roundtrip

### DIFF
--- a/S02-types/list.t
+++ b/S02-types/list.t
@@ -15,7 +15,7 @@ is ().raku, '()', '.raku on empty List';
 is ().item.raku, '$( )', '.item.raku on empty List';
 is-deeply ().item, ().item.raku.EVAL, 'can roundtrip ().item';
 #?rakudo.jvm skip 'dies with t/harness5'
-cmp-ok ().item.VAR, '===', ().item.raku.EVAL.VAR,
+cmp-ok ().item.VAR.WHAT, '===', ().item.raku.EVAL.VAR.WHAT,
     '().item .raku.EVAL roundtrip preserves itemization';
 
 # L<S02/Quoting forms/Elsewhere it is equivalent to a parenthesized list of strings>


### PR DESCRIPTION
The previous version of the test expected the same container to be preserved for an itemized list despite roundtripping it through `EVAL`. But this is incorrect because:

- we itemize two different lists despite both being empty
- why would method `item` always return same scalar container, whatever
  it wouldd mean in terms of comparing two containers
- and then we expect `EVAL` method to somehow preserve that container
  despite the string recevied from `raku` method does not provide us
  with any hints about the container details

So, the only correct approach for this test is to make sure that both lists: directly itemized and roundtripped one, - are contained by the same type of container.

In support of Raku/problem-solving#291