### PR TITLE
New tests for signature-constrained parameters

### DIFF
--- a/S03-smartmatch/signature-signature.t
+++ b/S03-smartmatch/signature-signature.t
@@ -1,6 +1,6 @@
 use v6;
 use Test;
-plan 24;
+plan 26;
 
 #L<S03/Smart matching/Signature-signature>
 {
@@ -36,6 +36,12 @@ plan 24;
 
     ok (:(&foo:(Str --> Bool)) ~~ :(&bar:(Str --> Bool))),
         "Code params with signatures";
+
+    nok (:(&foo:(Int --> Bool)) ~~ :(&bar:(Str --> Bool))),
+        "Code params with different signature parameters doesn't match";
+
+    nok (:(&foo:(Int --> Bool)) ~~ :(&bar:(Int --> Str))),
+        "Code params with different signature return types doesn't match";
 
     # https://github.com/Raku/old-issue-tracker/issues/5028
     nok :(Int --> Int) ~~ :(), 'Can smartmatch against empty signature (False)';

--- a/S03-smartmatch/signature-signature.t
+++ b/S03-smartmatch/signature-signature.t
@@ -34,7 +34,6 @@ plan 24;
     # Can't deal with parameters.
     ok (:(::T $x, T $y) R~~ :(Str $y, Str $z)), "Parametric types";
 
-    #?rakudo todo "Parametric types"
     ok (:(&foo:(Str --> Bool)) ~~ :(&bar:(Str --> Bool))),
         "Code params with signatures";
 


### PR DESCRIPTION
Cover issue rakudo/rakudo#4537 and support PR rakudo/rakudo#4538:

- Unfudged now passing tests
- Added some negative tests to make sure we're not positive only
- Added tests to make sure named constrained parameters work too
- Added tests for generics