### PR TITLE
Add more tests for type constraints in signature smartmatches

### DIFF
--- a/S03-smartmatch/signature-signature.t
+++ b/S03-smartmatch/signature-signature.t
@@ -1,6 +1,6 @@
 use v6;
 use Test;
-plan 33;
+plan 37;
 
 #L<S03/Smart matching/Signature-signature>
 {
@@ -27,9 +27,13 @@ plan 33;
          :($),                                      :($ ($, $)),                True,
          :($),                                      :(Int $ ($, $)),            True,
          :(Int $ ($, $)),                           :($ ($, $)),                False,
+         :(*@),                                     :($ ($, $)),                True,
+         :(|),                                      :($ ($, $)),                True,
          :(:$),                                     :(:$ ($, $)),               True,
          :(:$),                                     :(Int :$ ($, $)),           True,
          :(Int :$ ($, $)),                          :(:$ ($, $)),               False,
+         :(*%),                                     :(:$ ($, $)),               True,
+         :(|),                                      :(:$ ($, $)),               True,
          :(:$b ($, $)),                             :(:$a ($, $)),              False,
         );
 

--- a/S03-smartmatch/signature-signature.t
+++ b/S03-smartmatch/signature-signature.t
@@ -1,6 +1,6 @@
 use v6;
 use Test;
-plan 26;
+plan 33;
 
 #L<S03/Smart matching/Signature-signature>
 {
@@ -24,6 +24,13 @@ plan 26;
          :(:$x, Int :$y, Cool :$z, *%_),            :(*%_),                     False,
          :(:$x, *%_),                               :(:$x, *%_),                True,
          :(Mu, Any, Numeric),                       :(Mu, *@_),                 False,
+         :($),                                      :($ ($, $)),                True,
+         :($),                                      :(Int $ ($, $)),            True,
+         :(Int $ ($, $)),                           :($ ($, $)),                False,
+         :(:$),                                     :(:$ ($, $)),               True,
+         :(:$),                                     :(Int :$ ($, $)),           True,
+         :(Int :$ ($, $)),                          :(:$ ($, $)),               False,
+         :(:$b ($, $)),                             :(:$a ($, $)),              False,
         );
 
     for @tests -> $s1, $s2, $res {

--- a/S03-smartmatch/signature-signature.t
+++ b/S03-smartmatch/signature-signature.t
@@ -1,6 +1,6 @@
 use v6;
 use Test;
-plan 37;
+plan 38;
 
 #L<S03/Smart matching/Signature-signature>
 {
@@ -58,6 +58,15 @@ plan 37;
     nok :(Int --> Int) ~~ :(), 'Can smartmatch against empty signature (False)';
     nok :() ~~ :(Int ), 'Can smartmatch an empty signature (False)';
     ok :() ~~ :(), 'Can smartmatch against empty signature (True)';
+
+    ok none((
+        :($T? is raw),
+        :($T? is raw = Mu),
+        :($T? is raw where $T =:= $T.WHAT = Mu),
+        :(:$T? is raw),
+        :(:$T? is raw = Mu),
+        :(:$T? is raw where $T =:= $T.WHAT = Mu)
+    ) X~~ :()), 'Optional parameters do not get dropped in a smartmatch';
 }
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
Covers the bugs noted in https://github.com/rakudo/rakudo/issues/4558. Requires https://github.com/rakudo/rakudo/pull/4573.