### PR TITLE
Typecheck optional @/% parameters' defaults

### DIFF
--- a/S06-signature/defaults.t
+++ b/S06-signature/defaults.t
@@ -10,7 +10,7 @@ Tests assigning default values to variables of type code in sub definitions.
 
 # L<S06/Optional parameters/Default values can be calculated at run-time>
 
-plan 13;
+plan 17;
 
 sub doubler($x) { return 2 * $x }
 
@@ -72,15 +72,23 @@ ok((MyPack::val_v), "default sub called in package namespace");
 
 # https://github.com/rakudo/rakudo/issues/4647
 {
-    -> :@l { cmp-ok @l.WHAT, &[=:=], Array,
-        'untyped optional arrays get their default' }();
-    -> :%h { cmp-ok %h.WHAT, &[=:=], Hash,
-        'untyped optional hashes get their default' }();
-
-    -> Str :@l { cmp-ok @l.WHAT, &[=:=], Array[Str],
-        'typed optional arrays get their default' }();
-    -> Str :%h { cmp-ok %h.WHAT, &[=:=], Hash[Str],
-        'typed optional hashes get their default' }();
+    # Inlined to avoid errors in forwarding arguments to other routines.
+    -> :@l {
+        cmp-ok @l.WHAT, &[=:=], Array, 'untyped optional arrays get their default Array...';
+        ok @l.DEFINITE, '...which is an instance';
+    }();
+    -> Str :@l {
+        cmp-ok @l.WHAT, &[=:=], Array[Str], 'typed optional arrays get their default parameterized Array...';
+        ok @l.DEFINITE, '...which is an instance';
+    }();
+    -> :%h {
+        cmp-ok %h.WHAT, &[=:=], Hash, 'untyped optional hashes get their default Hash...';
+        ok %h.DEFINITE, '...which is an instance';
+    }();
+    -> Str :%h {
+        cmp-ok %h.WHAT, &[=:=], Hash[Str], 'typed optional hashes get their default parameterized Hash...';
+        ok %h.DEFINITE, '...which is an instance';
+    }();
 }
 
 # vim: expandtab shiftwidth=4

--- a/S06-signature/defaults.t
+++ b/S06-signature/defaults.t
@@ -72,11 +72,15 @@ ok((MyPack::val_v), "default sub called in package namespace");
 
 # https://github.com/rakudo/rakudo/issues/4647
 {
-    cmp-ok -> :@l { @l }(), &[eqv], my @, 'untyped optional arrays get their default';
-    cmp-ok -> :%h { %h }(), &[eqv], my %, 'untyped optional hashes get their default';
+    cmp-ok WHAT(-> :@l { @l }()), &[=:=], Array,
+        'untyped optional arrays get their default';
+    cmp-ok WHAT(-> :%h { %h }()), &[=:=], Hash,
+        'untyped optional hashes get their default';
 
-    cmp-ok -> Str :@l { @l }(), &[eqv], my Str @, 'typed optional arrays get their default';
-    cmp-ok -> Str :%h { %h }(), &[eqv], my Str %, 'typed optional hashes get their default';
+    cmp-ok WHAT(-> Str :@l { @l }()), &[=:=], Array[Str],
+        'typed optional arrays get their default';
+    cmp-ok WHAT(-> Str :%h { %h }()), &[=:=], Hash[Str],
+        'typed optional hashes get their default';
 }
 
 # vim: expandtab shiftwidth=4

--- a/S06-signature/defaults.t
+++ b/S06-signature/defaults.t
@@ -72,15 +72,15 @@ ok((MyPack::val_v), "default sub called in package namespace");
 
 # https://github.com/rakudo/rakudo/issues/4647
 {
-    cmp-ok WHAT(-> :@l { @l }()), &[=:=], Array,
-        'untyped optional arrays get their default';
-    cmp-ok WHAT(-> :%h { %h }()), &[=:=], Hash,
-        'untyped optional hashes get their default';
+    -> :@l { cmp-ok @l.WHAT, &[=:=], Array,
+        'untyped optional arrays get their default' }();
+    -> :%h { cmp-ok %h.WHAT, &[=:=], Hash,
+        'untyped optional hashes get their default' }();
 
-    cmp-ok WHAT(-> Str :@l { @l }()), &[=:=], Array[Str],
-        'typed optional arrays get their default';
-    cmp-ok WHAT(-> Str :%h { %h }()), &[=:=], Hash[Str],
-        'typed optional hashes get their default';
+    -> Str :@l { cmp-ok @l.WHAT, &[=:=], Array[Str],
+        'typed optional arrays get their default' }();
+    -> Str :%h { cmp-ok %h.WHAT, &[=:=], Hash[Str],
+        'typed optional hashes get their default' }();
 }
 
 # vim: expandtab shiftwidth=4

--- a/S06-signature/defaults.t
+++ b/S06-signature/defaults.t
@@ -10,7 +10,7 @@ Tests assigning default values to variables of type code in sub definitions.
 
 # L<S06/Optional parameters/Default values can be calculated at run-time>
 
-plan 9;
+plan 13;
 
 sub doubler($x) { return 2 * $x }
 
@@ -68,6 +68,15 @@ ok((MyPack::val_v), "default sub called in package namespace");
         ok $r ~~ Regex, 'rx{foo} works as a default';
     }
     foo();
+}
+
+# https://github.com/rakudo/rakudo/issues/4647
+{
+    cmp-ok -> :@l { @l }(), &[eqv], my @, 'untyped optional arrays get their default';
+    cmp-ok -> :%h { %h }(), &[eqv], my %, 'untyped optional hashes get their default';
+
+    cmp-ok -> Str :@l { @l }(), &[eqv], my Str @, 'typed optional arrays get their default';
+    cmp-ok -> Str :%h { %h }(), &[eqv], my Str %, 'typed optional hashes get their default';
 }
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
See https://github.com/rakudo/rakudo/pull/4648. Just check for the named variants, since the differences between them and optional positionals aren't relevant to `Binder`'s `&handle_optional`.