### PR TITLE
Tweak tests for error message for wrong arity

### DIFF
--- a/S02-types/built-in.t
+++ b/S02-types/built-in.t
@@ -8,15 +8,15 @@ plan 1;
 # L<S02/Built-In Data Types>
 
 # https://github.com/Raku/old-issue-tracker/issues/3413
-# TODO: better test (e.g. typed exception instead of testing for backend specific error messages
+# TODO: typed exception instead of testing for specific error message
 {
     throws-like {
         my $foo = ObjAt.new(:val("test"));
         $foo ~~ /"foo"/;
     },
-    Exception,
-    message => / 'Too few positionals passed; expected 2 arguments but got 1' /,
-        'no segfault in ObjAt initalization when passing bogus named parameters';
+        Exception,
+        message => / 'Too few positionals passed' .+ 'expected 2 arguments but got 1' /,
+        'no segfault in ObjAt initialization when passing bogus named arguments';
 }
 
 # vim: expandtab shiftwidth=4

--- a/S03-sequence/arity-2-or-more.t
+++ b/S03-sequence/arity-2-or-more.t
@@ -44,16 +44,10 @@ is (1, 1, 2, 3, { $^a + $^b } ... 9).[^7].join(', '), '1, 1, 2, 3, 5, 8, 13', 'a
 is (1, 2, sub {[*] @_[*-1], @_ + 1} ... 720).join(' '), '1 2 6 24 120 720', 'slurpy factorial generator';
 
 # https://github.com/Raku/old-issue-tracker/issues/3118
-# TODO: better test (e.g. typed exception instead of testing for backend specific error messages
+# TODO: typed exception instead of testing for specific error message
 {
     throws-like { ( ^1, *+* ... * )[^20] }, Exception,
-        message => {
-            m/
-                'Too few positionals passed; expected 2 arguments but got 1'
-                |
-                'Not enough positional parameters passed; got 1 but expected 2'
-            /
-        },
+        message => / 'Too few positionals passed' .+ 'expected 2 arguments but got 1' /,
         'no internals leaking out with series operator used wrongly (arity 2)';
 }
 


### PR DESCRIPTION
The tests are still very specific wrt the error message, but they now
allow to mention the method, for instance:

  $ ./rakudo -e 'my $foo = ObjAt.new(:val("test")); $foo ~~ /"foo"/;'
  Too few positionals passed to 'new'; expected 2 arguments but got 1
    in block <unit> at -e line 1

The old messages that talked about parameters have been removed back in
2015 with https://github.com/MoarVM/MoarVM/commit/288410e40d and
https://github.com/rakudo/rakudo/commit/3301ec44b7.