### PR TITLE
Change testing for cross-language revision class/role

### DIFF
--- a/packages/S14-roles/lib/Ver6c.rakumod
+++ b/packages/S14-roles/lib/Ver6c.rakumod
@@ -6,4 +6,17 @@ class Cv6c is export { }
 
 enum Enum-v6c is export <ca cb cc>;
 
+role R6c_1 is export {
+    submethod r6c { }
+}
+
+role R6c_2[@stages] {
+    submethod BUILD {
+        @stages.push: $?ROLE.^name ~ ".BUILD";
+    }
+    submethod TWEAK {
+        @stages.push: $?ROLE.^name ~ ".TWEAK";
+    }
+}
+
 # vim: expandtab shiftwidth=4

--- a/packages/S14-roles/lib/Ver6e.rakumod
+++ b/packages/S14-roles/lib/Ver6e.rakumod
@@ -7,4 +7,17 @@ class Cv6e is export { }
 
 enum Enum-v6e is export <ea eb ec>;
 
+role R6e_1 {
+    submethod r6e { }
+}
+
+role R6e_2[@stages] {
+    submethod BUILD {
+        @stages.push: $?ROLE.^name ~ ".BUILD";
+    }
+    submethod TWEAK {
+        @stages.push: $?ROLE.^name ~ ".TWEAK";
+    }
+}
+
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
Applying 6.e role to a pre-6.e class is no more an error. Make sure it
works as expected.

In support of rakudo/rakudo#4686