### PR TITLE
Adjust tests to better work with improved smartmatch dispatcher on MoarVM

### DIFF
--- a/S03-smartmatch/00-sanity.t
+++ b/S03-smartmatch/00-sanity.t
@@ -2,6 +2,10 @@ use v6;
 use Test;
 plan 2;
 
+my $seed = (($_ - .Int) * 1_000_000_000).Int with now;
+diag "Random seed: " ~ $seed;
+srand($seed);
+
 # Make sure that smarmatch doesn't return unexpected values. In particular, it must always return Boolean except for
 # when used with regexes.
 # Since optimizations may result in different code for matching directly against objects, when RHS is known exactly,
@@ -24,18 +28,25 @@ subtest "direct" => {
 }
 
 subtest "indirect" => {
-    plan 5;
-
+    # The order of tests here is randomized to ensure that any possible call-site bound caching of smartmatch outcomes,
+    # akin to the one taking place with new-disp implementation on Rakudo, doesn't happen too agressively. Note that if
+    # test fails then it can be reproduced with the reported above seed value.
     my sub test-sm(Mu $lhs, Mu $rhs --> Mu) is raw {
         $lhs ~~ $rhs
     }
 
-    isa-ok test-sm(1, 1).WHAT, Bool, "plan smartmatch return Bool";
-    isa-ok test-sm(any(1,2), 1).WHAT, Bool, "a junction on LHS doesn't autothread";
-    isa-ok test-sm(1, any(1,2)).WHAT, Bool, "a junction on RHS doesn't autothread";
-    isa-ok test-sm("123", /\d+/).WHAT, Match, "simple regex returns a Match object on success";
-    my $s = "1..5";
-    cmp-ok test-sm("abc", /\d+/), '===', Nil, "failed regex match returns Nil";
+    my @tests =
+        { isa-ok test-sm(1, 1).WHAT, Bool, "plan smartmatch return Bool"; },
+        { isa-ok test-sm(any(1,2), 1).WHAT, Bool, "a junction on LHS doesn't autothread"; },
+        { isa-ok test-sm(1, any(1,2)).WHAT, Bool, "a junction on RHS doesn't autothread"; },
+        { isa-ok test-sm("123", /\d+/).WHAT, Match, "simple regex returns a Match object on success"; },
+        { isa-ok test-sm("abc", /\d+/), Nil, "failed regex match returns Nil" };
+
+    plan +@tests;
+
+    for @tests.pick(*) -> &test-code {
+        test-code
+    }
 }
 
 

--- a/S03-smartmatch/00-sanity.t
+++ b/S03-smartmatch/00-sanity.t
@@ -35,12 +35,21 @@ subtest "indirect" => {
         $lhs ~~ $rhs
     }
 
+    my sub test-sm-negated(Mu $lhs, Mu $rhs --> Mu) is raw {
+        $lhs !~~ $rhs
+    }
+
     my @tests =
-        { isa-ok test-sm(1, 1).WHAT, Bool, "plan smartmatch return Bool"; },
-        { isa-ok test-sm(any(1,2), 1).WHAT, Bool, "a junction on LHS doesn't autothread"; },
-        { isa-ok test-sm(1, any(1,2)).WHAT, Bool, "a junction on RHS doesn't autothread"; },
+        { isa-ok test-sm(1, 1).WHAT,         Bool,  "plain smartmatch return Bool"; },
+        { isa-ok test-sm(any(1,2), 1).WHAT,  Bool,  "a junction on LHS doesn't autothread"; },
+        { isa-ok test-sm(1, any(1,2)).WHAT,  Bool,  "a junction on RHS doesn't autothread"; },
         { isa-ok test-sm("123", /\d+/).WHAT, Match, "simple regex returns a Match object on success"; },
-        { isa-ok test-sm("abc", /\d+/), Nil, "failed regex match returns Nil" };
+        { isa-ok test-sm("abc", /\d+/),      Nil,   "failed regex match returns Nil" },
+        { isa-ok test-sm-negated(1, 1).WHAT,         Bool, "negated plain smartmatch return Bool"; },
+        { isa-ok test-sm-negated(any(1,2), 1).WHAT,  Bool, "negated: a junction on LHS doesn't autothread"; },
+        { isa-ok test-sm-negated(1, any(1,2)).WHAT,  Bool, "negated: a junction on RHS doesn't autothread"; },
+        { isa-ok test-sm-negated("123", /\d+/).WHAT, Bool, "negated simple regex returns a Bool object"; },
+        { isa-ok test-sm-negated("abc", /\d+/),      Bool, "negated failed regex match returns Bool" };
 
     plan +@tests;
 

--- a/S12-meta/primitives.t
+++ b/S12-meta/primitives.t
@@ -2,7 +2,7 @@ use v6;
 
 use Test;
 
-plan 19;
+plan 21;
 
 {
     my $union-type-checks = 0;
@@ -10,32 +10,36 @@ plan 19;
 
     class UnionTypeHOW {
         has @!types;
+        has $.name;
 
         submethod BUILD(:@!types) { }
 
         method new_type(*@types) {
             my $how = self.new(:@types);
             my $type = Metamodel::Primitives.create_type($how, 'Uninstantiable');
+            $type.^set_name: @types.map({ .^name }).join(' | ');
             $type
         }
 
-        method name($) {
-            @!types.map({ .^name }).join(' | ');
+        method set_name(Mu $, $!name) {}
+
+        method name(Mu $) {
+            $!name
         }
 
-        method compose($type) {
+        method compose(Mu $type) {
             # Set up type checking with cache.
             Metamodel::Primitives.configure_type_checking($type,
-                [@!types, Any, Mu],
+                [|@!types, Any, Mu],
                 :authoritative, :call_accepts);
 
             $type
         }
 
         method type_check(Mu $, Mu \check) {
-            $union-type-checks++;
-            for flat @!types, Any, Mu {
-                return True if Metamodel::Primitives.is_type(check, $_);
+            ++$union-type-checks;
+            for |@!types, Any, Mu {
+                return True if check<> =:= $_<>
             }
             return False;
         }
@@ -47,7 +51,7 @@ plan 19;
             return False;
         }
 
-        method find_method($, $name) {
+        method find_method(Mu $, $name) {
             $union-find-method-calls++;
             Any.^find_method($name);
         }
@@ -65,7 +69,8 @@ plan 19;
     nok 420 ~~ $int-or-rat, 'Union type broken before compose (3)';
     nok 4.2 ~~ $int-or-rat, 'Union type broken before compose (4)';
 
-    ok $union-type-checks >= 4, 'Type checking called method before compose';
+    ok $int-or-rat ~~ Int, "Union type ok before comopes if on LHS";
+    ok $union-type-checks > 0, 'Type checking called method before compose';
     ok $union-find-method-calls >= 1, 'ACCEPTS method lookup before compose';
 
     $int-or-rat.^compose;
@@ -79,6 +84,8 @@ plan 19;
     ok 4.2 ~~ $int-or-rat, 'Union type works with cache (4)';
     nok Str ~~ $int-or-rat, 'Union type works with cache (5)';
     nok 'w' ~~ $int-or-rat, 'Union type works with cache (6)';
+
+    ok $int-or-rat ~~ Int, "Union type ok after comopes if on LHS";
 
     # https://github.com/Raku/old-issue-tracker/issues/3606
     #?rakudo.jvm 1 todo 'RT #123426'


### PR DESCRIPTION
- Fixed errors in a test of `Metamodel::Primitives` revealed by further smartmatch improvements
- Randomized order of tests in smartmatch sanity testing in order to increase chances of catching some order-dependent class of regressions.