### PR TITLE
Accommodate tests to fixes of classification over junctions

### DIFF
--- a/S32-list/categorize.t
+++ b/S32-list/categorize.t
@@ -7,9 +7,9 @@ plan 28;
 
 { # basic categorize with all possible mappers
     my @list      = 29, 7, 12, 9, 18, 23, 3, 7;
-    my %expected1{Any} =
+    my %expected1{Mu} =
       (0=>[7,9,3,7],         10=>[12,18],       20=>[29,23]);
-    my %expected2{Any} =
+    my %expected2{Mu} =
       (0=>[7,9,3,7,7,9,3,7], 10=>[12,18,12,18], 20=>[29,23,29,23]);
     my sub subber ($a) { $a - ($a % 10) };
     my $blocker = { $_ - ($_ % 10) };
@@ -22,14 +22,14 @@ plan 28;
         is-deeply @list.categorize( $mapper ), %expected1,
           "method call on list with {$mapper.^name}";
 
-        categorize( $mapper, @list, :into(my %h{Any}) );
+        categorize( $mapper, @list, :into(my %h{Mu}) );
         is-deeply %h, %expected1,
           "basic categorize as sub with {$mapper.^name} and new into";
         categorize( $mapper, @list, :into(%h) );
         is-deeply %h, %expected2,
           "basic categorize as sub with {$mapper.^name} and existing into";
 
-        @list.categorize( $mapper, :into(my %i{Any}) );
+        @list.categorize( $mapper, :into(my %i{Mu}) );
         is-deeply %i, %expected1,
           "basic categorize from list with {$mapper.^name} and new into";
         @list.categorize( $mapper, :into(%i) );
@@ -63,7 +63,7 @@ plan 28;
 {
     # Method form, code block mapper, using :as
     my %got = (1...6).categorize: {
-        my @categories = ( $_ % 2 ?? 'odd' !! 'even');
+        my @categories = ($_ % 2) ?? 'odd' !! 'even';
         unless $_ % 3 { push @categories, 'triple'}
         @categories;
     }, :as(* * 10);
@@ -90,12 +90,12 @@ plan 28;
 
 {
     is-deeply( categorize( { map { [$_+0, $_+10] }, .comb }, 100,104,112,119 ),
-      (my %{Any} =
-        1 => ( my %{Any} = 11 => [100, 104, 112, 112, 119, 119] ),
-        0 => ( my %{Any} = 10 => [100, 100, 104] ),
-        4 => ( my %{Any} = 14 => [104] ),
-        2 => ( my %{Any} = 12 => [112] ),
-        9 => ( my %{Any} = 19 => [119] ),
+      (my %{Mu} =
+        1 => ( my %{Mu} = 11 => [100, 104, 112, 112, 119, 119] ),
+        0 => ( my %{Mu} = 10 => [100, 100, 104] ),
+        4 => ( my %{Mu} = 14 => [104] ),
+        2 => ( my %{Mu} = 12 => [112] ),
+        9 => ( my %{Mu} = 19 => [119] ),
       ), 'multi-level categorize' );
 }
 

--- a/S32-list/classify.t
+++ b/S32-list/classify.t
@@ -7,10 +7,10 @@ plan 40;
 
 {
     my @list = 1, 2, 3, 4;
-    my %classified1{Any} = even => [2,4],     odd => [1,3];
-    my %classified2{Any} = even => [2,4,2,4], odd => [1,3,1,3];
-    my sub subber ($a) { $a % 2 ?? 'odd' !! 'even' };
-    my $blocker = { $_ % 2 ?? 'odd' !! 'even' };
+    my %classified1{Mu} = even => [2,4],     odd => [1,3];
+    my %classified2{Mu} = even => [2,4,2,4], odd => [1,3,1,3];
+    my sub subber ($a) { ($a % 2) ?? 'odd' !! 'even' };
+    my $blocker = { ($_ % 2) ?? 'odd' !! 'even' };
     my $hasher  = { 1 => 'odd', 2 => 'even', 3 => 'odd', 4 => 'even' };
     my $arrayer = <huh odd even odd even>.list;
 
@@ -20,14 +20,14 @@ plan 40;
         is-deeply classify( $classifier, @list ), %classified1,
           "basic classify as subroutine with {$classifier.^name}";
 
-        classify( $classifier, @list, :into(my %h{Any}) );
+        classify( $classifier, @list, :into(my %h{Mu}) );
         is-deeply %h, %classified1,
           "basic classify as sub with {$classifier.^name} and new into";
         classify( $classifier, @list, :into(%h) );
         is-deeply %h, %classified2,
           "basic classify as sub with {$classifier.^name} and existing into";
 
-        @list.classify( $classifier, :into(my %i{Any}) );
+        @list.classify( $classifier, :into(my %i{Mu}) );
         is-deeply %i, %classified1,
           "basic classify from list with {$classifier.^name} and new into";
         @list.classify( $classifier, :into(%i) );
@@ -53,10 +53,10 @@ plan 40;
 } #3
 
 {
-    my %result{Any} = 5 => [1], 10 => [2], 15 => [3], 20 => [4];
+    my %result{Mu} = 5 => [1], 10 => [2], 15 => [3], 20 => [4];
     is-deeply classify( { $_ * 5 }, 1, 2, 3, 4 ), %result,
       'can classify by numbers';
-    classify( { $_ * 5 }, 1, 2, 3, 4, :into(my %by_five{Any}) );
+    classify( { $_ * 5 }, 1, 2, 3, 4, :into(my %by_five{Mu}) );
     is-deeply %by_five, %result,
       'can classify by numbers into an existing empty hash';
     classify( { $_ * 5 }, 1, 2, 3, 4, :into(%by_five) );
@@ -71,15 +71,15 @@ plan 40;
 
 # .classify should work on non-arrays
 {
-    is-deeply 42.classify(  {$_} ), (my %{Any} = 42 => [42]), "classify single num";
-    is-deeply "A".classify( {$_} ), (my %{Any} = A => ["A"]), "classify single string";
+    is-deeply 42.classify(  {$_} ), (my %{Mu} = 42 => [42]), "classify single num";
+    is-deeply "A".classify( {$_} ), (my %{Mu} = A => ["A"]), "classify single string";
 } #2
 
 {
     is-deeply( classify( {.comb}, flat 100 .. 119, 104, 119 ),
-      (my %{Any} =
-        "1" => (my %{Any} =
-          "0" => (my %{Any} =
+      (my %{Mu} =
+        "1" => (my %{Mu} =
+          "0" => (my %{Mu} =
             "0" => [100],
             "1" => [101],
             "2" => [102],
@@ -91,7 +91,7 @@ plan 40;
             "8" => [108],
             "9" => [109],
           ),
-          "1" => (my %{Any} =
+          "1" => (my %{Mu} =
             "0" => [110],
             "1" => [111],
             "2" => [112],
@@ -113,26 +113,26 @@ is classify( { "foo" }, () ).elems, 0, 'classify an empty list';
 {
     is-deeply
         <a b c>.classify({ ~($ ~= $_); }),
-        (my %{Any} = 'a' => ['a'], 'ab' => ['b'], 'abc' => ['c']),
+        (my %{Mu} = 'a' => ['a'], 'ab' => ['b'], 'abc' => ['c']),
         '&test only run once for each item';
 }
 
 # https://github.com/Raku/old-issue-tracker/issues/5205
+# https://github.com/Raku/problem-solving/issues/312
 subtest 'classify works with Junctions' => {
-    plan 4;
+    plan 6;
     # Since we're returning a Junction from the mapper, it'll thread, sticking
     # the values multiple times under the keys. Due to possible
     # short-curcuiting of the Junctions, the number of inserted values may
     # differ depending on the implementation, so we'll only test which values
     # are present and absent under each key
-    my @l := <abc abcdef xyz>;
-    my $m := @l.classify: *.contains: any 'a'..'f';
-    my $s :=    classify  *.contains( any 'a'..'f'), @l;
+    my @l := <abc axz abcdef axyf cbd xyz>;
+    my $m := @l.classify: *.contains: any 'a','f';
+    my $s :=    classify  *.contains( any 'a','f'), @l;
     for 'method', $m,  'sub', $s -> $form, $v {
-        cmp-ok $v.{True }, '~~', {$_ ∋ all 'abc', 'abcdef', none 'xyz'   },
-            "$form form (True  key)";
-        cmp-ok $v.{False}, '~~', {$_ ∋ all 'abc', 'xyz',    none 'abcdef'},
-            "$form form (False key)";
+        is-deeply $v{ any(False, False) }.sort, <cbd xyz>,     "non-matching";
+        is-deeply $v{ any(True, False)  }.sort, <abc axz>,     "part-matching";
+        is-deeply $v{ any(True, True)   }.sort, <abcdef axyf>, "full-matching";
     }
 }
 


### PR DESCRIPTION
The previous version of these tests was a statement of buggy behavior where classify was autothreading over junctions internally and producing incorrect results. This version establishes less confusing and more useful standard of method's behavior.

Note that in order to pass `classify.t` currently requires PR rakudo/rakudo#4769 as only when junctions are value objects the classification would correctly put all values into the same basket. Otherwise we're going to end up with indivudual key for each single junction object even if two or more of them are identical.

- resolves raku/problem-solving#312
- requires rakudo/rakudo#4770 and rakudo/rakudo#4769