### PR TITLE
Fix over-specific regression test

### DIFF
--- a/S12-attributes/instance.t
+++ b/S12-attributes/instance.t
@@ -695,13 +695,13 @@ throws-like q[class RT74274 { has $!a }; my $a = RT74274.new(a => 42);
       X::Comp::Trait::Unknown,
       type      => 'is',
       subtype   => 'bar',
-      declaring => 'n attribute',
+      declaring => /attribute/,
     ;
     throws-like 'class Zapwill { has $.a will bar { ... } }',
       X::Comp::Trait::Unknown,
       type      => 'will',
       subtype   => 'bar',
-      declaring => 'n attribute',
+      declaring => /attribute/,
     ;
 }
 


### PR DESCRIPTION
Two S12-attribute regression tests checked the exact value of an error's `$.declaring` property (expecting it to be `n attribute`).  This
changes the matcher to test that `$.declaring` contains `attribute`, which seems more robust.

This supports rakudo/rakudo#4786 (which changes `$.declaring` from `'n attribute'` to `'an attribute'`) but, because the test is overspecific, I believe this PR to be justified regardless of whether that one is merged.