### PR TITLE
Add more IO::Path::parent tests

### DIFF
--- a/S32-io/io-path-cygwin.t
+++ b/S32-io/io-path-cygwin.t
@@ -65,13 +65,20 @@ is $relpath.absolute("/foo").IO.relative("\\foo"), "foo/bar", "absolute inverts 
 #?rakudo 1 todo 'resolve NYI, needs nqp::readlink'
 is $abspath.relative.IO.absolute.IO.resolve, "\\foo\\bar", "absolute inverts relative with resolve";
 
-is IO::Path::Cygwin.new("foo/bar").parent,        "foo",            "parent of 'foo/bar' is 'foo'";
-is IO::Path::Cygwin.new("foo").parent,            ".",            "parent of 'foo' is '.'";
-is IO::Path::Cygwin.new(".").parent,            "..",            "parent of '.' is '..'";
-is IO::Path::Cygwin.new("..").parent,            "../..",        "parent of '..' is '../..'";
-is IO::Path::Cygwin.new("/foo").parent,            "/",            "parent at top level is '/'";
-is IO::Path::Cygwin.new("/").parent,            "/",            "parent of root is '/'";
-is IO::Path::Cygwin.new("\\").parent,            "/",            "parent of root ('\\') is '/'";
+is IO::Path::Cygwin.new("foo/bar").parent, "foo",       "parent of 'foo/bar' is 'foo'";
+is IO::Path::Cygwin.new("foo").parent,     ".",         "parent of 'foo' is '.'";
+is IO::Path::Cygwin.new(".").parent,       "..",        "parent of '.' is '..'";
+is IO::Path::Cygwin.new("..").parent,      "../..",     "parent of '..' is '../..'";
+is IO::Path::Cygwin.new("/foo").parent,    "/",         "parent at top level is '/'";
+is IO::Path::Cygwin.new("/").parent,       "/",         "parent of root is '/'";
+is IO::Path::Cygwin.new("\\").parent,      "/",         "parent of root ('\\') is '/'";
+is IO::Path::Cygwin.new("../foo").parent,  "..",        "parent of '../foo' is '..'";
+is IO::Path::Cygwin.new("foo/..").parent,  "foo/../..", "parent of 'foo/..' is 'foo/../..'";
+
+is IO::Path::Cygwin.new("/foo/bar").parent,    "/foo",       "parent of '/foo/bar' is '/foo'";
+is IO::Path::Cygwin.new("/foo").parent,        "/",          "parent of '/foo' is '/'";
+is IO::Path::Cygwin.new("/foo/..").parent,     "/foo/../..", "parent of '/foo/..' is '/foo/../..'";
+is IO::Path::Cygwin.new("/foo/../bar").parent, "/foo/..",    "parent of '/foo/../bar' is '/foo/..'";
 
 is IO::Path::Cygwin.new("/").child('foo'),    "/foo",        "append to root";
 is IO::Path::Cygwin.new(".").child('foo'),    "foo",        "append to cwd";

--- a/S32-io/io-path-unix.t
+++ b/S32-io/io-path-unix.t
@@ -50,12 +50,19 @@ is $relpath.absolute("/foo").IO.relative("/foo"),
 #?rakudo 1 todo 'resolve NYI, needs nqp::readlink'
 is $abspath.relative.IO.absolute.IO.resolve, "/foo/bar", "absolute inverts relative with resolve";
 
-is IO::Path::Unix.new("foo/bar").parent, "foo",   "parent of 'foo/bar' is 'foo'";
-is IO::Path::Unix.new("foo").parent,     ".",     "parent of 'foo' is '.'";
-is IO::Path::Unix.new(".").parent,       "..",    "parent of '.' is '..'";
-is IO::Path::Unix.new("..").parent,      "../..", "parent of '..' is '../..'";
-is IO::Path::Unix.new("/foo").parent,    "/",     "parent at top level is '/'";
-is IO::Path::Unix.new("/").parent,       "/",     "parent of root is '/'";
+is IO::Path::Unix.new("foo/bar").parent, "foo",       "parent of 'foo/bar' is 'foo'";
+is IO::Path::Unix.new("foo").parent,     ".",         "parent of 'foo' is '.'";
+is IO::Path::Unix.new(".").parent,       "..",        "parent of '.' is '..'";
+is IO::Path::Unix.new("..").parent,      "../..",     "parent of '..' is '../..'";
+is IO::Path::Unix.new("/foo").parent,    "/",         "parent at top level is '/'";
+is IO::Path::Unix.new("/").parent,       "/",         "parent of root is '/'";
+is IO::Path::Unix.new("../foo").parent,  "..",        "parent of '../foo' is '..'";
+is IO::Path::Unix.new("foo/..").parent,  "foo/../..", "parent of 'foo/..' is 'foo/../..'";
+
+is IO::Path::Unix.new("/foo/bar").parent,    "/foo",       "parent of '/foo/bar' is '/foo'";
+is IO::Path::Unix.new("/foo").parent,        "/",          "parent of '/foo' is '/'";
+is IO::Path::Unix.new("/foo/..").parent,     "/foo/../..", "parent of '/foo/..' is '/foo/../..'";
+is IO::Path::Unix.new("/foo/../bar").parent, "/foo/..",    "parent of '/foo/../bar' is '/foo/..'";
 
 is IO::Path::Unix.new("/").child('foo'), "/foo",  "append to root";
 is IO::Path::Unix.new(".").child('foo'), "foo",   "append to cwd";

--- a/S32-io/io-path-win.t
+++ b/S32-io/io-path-win.t
@@ -65,12 +65,19 @@ is $relpath.absolute("/foo").IO.relative("\\foo"), "foo\\bar","absolute inverts 
 #?rakudo 1 todo 'resolve NYI, needs nqp::readlink'
 is $abspath.relative.IO.absolute.IO.resolve, "\\foo\\bar",    "absolute inverts relative with resolve";
 
-is IO::Path::Win32.new("foo/bar").parent, "foo",    "parent of 'foo/bar' is 'foo'";
-is IO::Path::Win32.new("foo").parent,     ".",      "parent of 'foo' is '.'";
-is IO::Path::Win32.new(".").parent,       "..",     "parent of '.' is '..'";
-is IO::Path::Win32.new("..").parent,      "..\\..", "parent of '..' is '../..'";
-is IO::Path::Win32.new("\\foo").parent,   "\\",     "parent at top level is '/'";
-is IO::Path::Win32.new("\\").parent,      "\\",     "parent of root is '/'";
+is IO::Path::Win32.new("foo/bar").parent, "foo",         "parent of 'foo/bar' is 'foo'";
+is IO::Path::Win32.new("foo").parent,     ".",           "parent of 'foo' is '.'";
+is IO::Path::Win32.new(".").parent,       "..",          "parent of '.' is '..'";
+is IO::Path::Win32.new("..").parent,      "..\\..",      "parent of '..' is '../..'";
+is IO::Path::Win32.new("\\foo").parent,   "\\",          "parent at top level is '/'";
+is IO::Path::Win32.new("\\").parent,      "\\",          "parent of root is '/'";
+is IO::Path::Win32.new("..\\foo").parent, "..",          "parent of '../foo' is '..'";
+is IO::Path::Win32.new("foo\\..").parent, "foo\\..\\..", "parent of 'foo/..' is 'foo/../..'";
+
+is IO::Path::Win32.new("A:\\foo\\bar").parent,     "A:\\foo",         "parent of '/foo/bar' is '/foo'";
+is IO::Path::Win32.new("A:\\foo").parent,          "A:\\",            "parent of '/foo' is '/'";
+is IO::Path::Win32.new("A:\\foo\\..").parent,      "A:\\foo\\..\\..", "parent of '/foo/..' is '/foo/../..'";
+is IO::Path::Win32.new("A:\\foo\\..\\bar").parent, "A:\\foo\\..",     "parent of '/foo/../bar' is '/foo/..'";
 
 is IO::Path::Win32.new("\\").child('foo'), "\\foo", "append to root";
 is IO::Path::Win32.new(".").child('foo'),  "foo",   "append to cwd";


### PR DESCRIPTION
Specifically test absolute paths containing updirs and paths only made up
of updirs but still having a basename.

Needs rakudo/rakudo#4795 merged to pass.