### PR TITLE
Update list of dirs for test statistics

### DIFF
--- a/test_summary
+++ b/test_summary
@@ -68,7 +68,7 @@ for my $tfile (@tfiles) {
 
 # Prepare arrays and hashes to gather and accumulate test statistics
 my @col = qw(pass fail todo skip plan spec);
-my @syn = qw(S01 S02 S03 S04 S05 S06 S07 S09 S10 S11 S12 S13 S14 S15 S16 S17 S19 S22 S24 S26 S28 S29 S32 int ros);
+my @syn = qw(6.c 6.d APP MIS S01 S02 S03 S04 S05 S06 S07 S09 S10 S11 S12 S13 S14 S15 S16 S17 S19 S22 S24 S26 S28 S29 S32 int);
 my %syn; # number of test scripts per Synopsis
 my %sum; # total pass/fail/todo/skip/test/plan per Synposis
 my $syn;


### PR DESCRIPTION
This reflects some recent changes of the directory structure for tests:

* Tests for Rosettacode have been removed in 2023-02, see https://github.com/Raku/roast/commit/504f0265ee
* Specific tests for 6.c and 6.d have been moved to dedicated dirs in https://github.com/Raku/roast/commit/720a5dc1f8 and follow-up commits

The change to the list of dirs doesn't really change the functionality of the script. It only avoids some warnings/errors regarding unknown or non-existing dirs. (One could argue that either the variable name or the logic of grouping tests per Synopsis should be updated, because the directory structure doesn't match the Synopsis names anymore. But maybe it's not worth the trouble.)