### PR TITLE
Fix tests for arrays that aren't shaped

### DIFF
--- a/S02-types/array-shapes.t
+++ b/S02-types/array-shapes.t
@@ -25,13 +25,12 @@ plan 42;
 {
     lives-ok { my @arr\    [7] },
       'array with fixed size with unspace';
-   #?rakudo 2 todo 'code does not die, array shapes'
-    throws-like 'my @arr.[8]',
-      Exception,  # XXX fix when this block is no longer skipped
-      'array with dot form dies';
-    throws-like 'my @arr\    .[8]',
-      Exception,  # XXX fix when this block is no longer skipped
-      'array with dot form and unspace dies';
+    my @arr1.[2] = 42;
+    is-deeply @arr1, [Any, Any, 42],
+      'dotted form just calls &postcircumfix:<[ ]>, no shaped array is created';
+    my @arr2\  .[2] = "foo";
+    is-deeply @arr2, [Any, Any, "foo"],
+      'dotted form with unspace also just calls &postcircumfix:<[ ]>';
 }
 
 # L<S09/Typed arrays>


### PR DESCRIPTION
It looks like these tests have been added on the wrong assumption that adding a dot between the array name and the shape declaration should fail. At the time when the tests were added the synopsis (S09-data.pod) stated that those forms are errors. Later on it was clarified that they aren't supposed to die, but just can't be used to declare shaped arrays: https://github.com/Raku/old-design-docs/commit/e8527c2291.