### PR TITLE
Add tests for log2

### DIFF
--- a/S32-num/cool-num.t
+++ b/S32-num/cool-num.t
@@ -1,5 +1,6 @@
 use Test;
-plan 46;
+
+plan 48;
 
 =begin pod
 
@@ -28,6 +29,7 @@ is-approx NotComplex.new.exp("2"), $magic.exp("2"), 'NotComplex.new.exp("2") == 
 is-approx "3".exp(NotComplex.new), 3.exp($magic), '"3".exp(NotComplex.new) == 3.exp($magic)';
 is-approx NotComplex.new.exp(NotComplex.new), $magic.exp($magic), 'NotComplex.new.exp(NotComplex.new) == $magic.exp($magic)';
 
+# LOG ================
 is-approx "17".log, 17.log, '"17".log == 17.log';
 is-approx NotComplex.new.log, $magic.log, 'NotComplex.new.log == $magic.log';
 is-approx "17".log("17"), 17.log(17), '"17".log("17") == 17.log(17)';
@@ -35,8 +37,13 @@ is-approx NotComplex.new.log("17"), $magic.log(17), 'NotComplex.new.log("17") ==
 is-approx "17".log(NotComplex.new), 17.log($magic), '"17".log("17") == 17.log(17)';
 is-approx NotComplex.new.log(NotComplex.new), $magic.log($magic), 'NotComplex.new.log(NotComplex.new) == $magic.log($magic)';
 
+# LOG10 ================
 is-approx "17".log10, 17.log10, '"17".log10 == 17.log10';
 is-approx NotComplex.new.log10, $magic.log10, 'NotComplex.new.log10 == $magic.log10';
+
+# LOG2 ================
+is-approx "17".log2, 17.log2, '"17".log2 == 17.log2';
+is-approx NotComplex.new.log2, $magic.log2, 'NotComplex.new.log2 == $magic.log2';
 
 is-approx "17".sqrt, 17.sqrt, '"17".sqrt == 17.sqrt';
 is-approx NotComplex.new.sqrt, $magic.sqrt, 'NotComplex.new.sqrt == $magic.sqrt';

--- a/S32-num/log.t
+++ b/S32-num/log.t
@@ -1,16 +1,35 @@
 use Test;
-plan 29;
+plan 34;
 
 =begin pod
 
-Basic tests for the log() and log10() builtins
+Basic tests for the log(), log2(), and log10() builtins
 
 =end pod
 
 my $log_5 = 940945/584642;
 my $log_one_tenth = -254834/110673;
+
+# Note the log2 of negative numbers is undefined, and the log2 of
+# numbers less than one approaches zero as the numbers approach
+# zero. See a graph of the function of this 'binary logarithm' on
+# Wikipedia (https://en.m.wikipedia.org/wiki/Binary_algorithm).
+
+my $log2_1 = 0;
+my $log2_2 = 1;
+my $log2_4 = 2;
+my $log2_8 = 3;
+
+# Conversion from other bases:
+#   log2 n = ln n / ln 2 = log10 n / log10 2
+#      or approximately:
+#   log2n ~= 1.442695 ln n ~= 3.321928 log10 n
+my $log2_5 = log(5) / log(2);
+my $log2_one_tenth = log(0.1) / log(2);
+
 my $log10_5 = 49471/70777;
 my $log10_one_tenth = -1;
+
 my $pi = 312689/99532;
 
 # L<S32::Numeric/Numeric/"=item log">
@@ -27,14 +46,19 @@ is-approx(log("42", "23"),  1.192051192, 'log(42, 23) with strings');
 
 # L<S32::Numeric/Numeric/"=item log10">
 
+is-approx(log2(5), $log2_5, 'got the log2 of 5');
+is-approx(log2(0.1), $log2_one_tenth, 'got the log2 of 0.1');
+
 is-approx(log10(5), $log10_5, 'got the log10 of 5');
 is-approx(log10(0.1), $log10_one_tenth, 'got the log10 of 0.1');
 
 is( log(0), -Inf, 'log(0) = -Inf');
-
 is( log(Inf), Inf, 'log(Inf) = Inf');
 is( log(-Inf), NaN, 'log(-Inf) = NaN');
 is( log(NaN), NaN, 'log(NaN) = NaN');
+
+is( log2(Inf), Inf, 'log2(Inf) = Inf');
+is( log2(NaN), NaN, 'log2(NaN) = NaN');
 
 is( log10(0), -Inf, 'log10(0) = -Inf');
 is( log10(Inf), Inf, 'log10(Inf) = Inf');
@@ -42,8 +66,6 @@ is( log10(-Inf), NaN, 'log10(-Inf) = NaN');
 is( log10(NaN), NaN, 'log10(NaN) = NaN');
 
 
-# please add tests for complex numbers
-#
 # The closest I could find to documentation is here: http://tinyurl.com/27pj7c
 # I use 1i instead of i since I don't know if a bare i will be supported
 
@@ -53,11 +75,21 @@ is-approx(log10(-1 + 0i), 0 + 1i * $pi / log(10), "got the log10 of -1");
 
 # log(exp(1+i pi)) = 1 + i pi
 is-approx(log(-exp(1) + 0i), 1 + 1i * $pi, "got the log of -e");
+
+# Conversion from other bases:
+#   log2 n = ln n / ln 2 = log10 n / log10 2
+#      or approximately:
+#   log2n ~= 1.442695 ln n ~= 3.321928 log10 n
+my $log2_10 = log(10) / log(2);
+is-approx(log2(10), $log2_10, 'log2(10)=?');
 is-approx(log10(-10 + 0i), 1 + 1i * $pi / log(10), "got the log10 of -10");
 is-approx(log10(10), 1.0, 'log10(10)=1');
 
 is-approx(log((1+1i) / sqrt(2)), 0 + 1i * $pi / 4, "got log of exp(i pi/4)");
 is-approx(log(1i), 1i * $pi / 2, "got the log of i (complex unit)");
+
+#is-approx(log2(1i), 1i * $pi / (2*$log2_10), 'got the log2 of i');
+#is-approx(log2((1+1i) / sqrt(2)), 0 + 1i * $pi / (4*log(10)), "got log2 of exp(i pi/4)");
 
 is-approx(log10(1i), 1i * $pi / (2*log(10)), 'got the log10 of i');
 is-approx(log10((1+1i) / sqrt(2)), 0 + 1i * $pi / (4*log(10)), "got log10 of exp(i pi/4)");
@@ -66,6 +98,12 @@ is-approx(log(-1i), -0.5i * $pi , "got the log of -i (complex unit)");
 is-approx(log10(-1i), -0.5i * $pi / log(10), "got the log10 of -i (complex unit)");
 
 # TODO: please add more testcases for log10 of complex numbers
+# See new test file for issue #862: S34-num/complex-logarithms.t
+
+# Conversion from other bases:
+#   log2 n = ln n / ln 2 = log10 n / log10 2
+#      or approximately:
+#   log2n ~= 1.442695 ln n ~= 3.321928 log10 n
 
 is-approx( (-1i).log10(), -0.5i*$pi / log(10), " (i).log10 = - i  * pi/(2 log(10))");
 isa-ok( log10(-1+0i), Complex, 'log10 of a complex returns a complex, not a list');


### PR DESCRIPTION
Routine 'log2' was incorporated into core earlier, but tests were not added then. This PR adds basic coverage for 'log2'.