### PR TITLE
s/`|w`/`?wb`/ (switch from Rakudo feature to Raku feature)

### DIFF
--- a/S32-io/IO-Socket-INET.t
+++ b/S32-io/IO-Socket-INET.t
@@ -311,7 +311,7 @@ do-test
 }
 
 if $*DISTRO.is-win            or  # test for WSL below
-   $*KERNEL.name eq "linux"   and $*KERNEL.release ~~ /:i <|w>Microsoft<|w>/ {
+   $*KERNEL.name eq "linux"   and $*KERNEL.release ~~ /:i <?wb>Microsoft<?wb>/ {
     # https://github.com/Raku/old-issue-tracker/issues/6094
     skip 'Winsock 1 second delay for connection failure RT #130892', 1
 }


### PR DESCRIPTION
It's OK if this PR is left to sit, or is rejected, but I'm posting it to tie up the last [loose end](https://github.com/Raku/doc/pull/4435#:~:text=Bottom%20line%3A,up%20loose%20ends.)) I'm aware of regarding `<|w>`.

[A search of roast for `|w` reveals one match, just one, no more, no less](https://github.com/search?q=repo%3ARaku%2Froast+%22%3C%7Cw%22&type=code).

That demonstrates that although `|w` was "spec"d (speculated) in the design docs as one of a range of `<|X>` features (where `X` is a character class), and is implemented in Rakudo, it is not (currently) roasted, and as the [discussion about this in the doc repo](https://github.com/Raku/doc/pull/4435), led to its removal from the Raku doc, I decided to write this PR.