### PR TITLE
Clarify that Roast is © the Raku Foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,4 +158,8 @@ too long a time by default so as to make the roast run faster.  Defaults to `1`.
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md)
+Roast is Copyright © [The Raku Foundation](https://raku.foundation) and is
+distributed under the terms of the Artistic License 2.0 (see [LICENSE](LICENSE)
+file for details).
+
+To contribute to Roast, please refer to [CONTRIBUTING.md](CONTRIBUTING.md)


### PR DESCRIPTION
This PR updates the README to explicitly state that Roast is © the Raku Foundation (TRF). This change is purely for clarity and does not alter any existing copyright ownership. It ensures that readers understand TRF is the designated entity for Raku-related program applications (e.g., the JetBrains Open Source license for IntelliJ, which I am in the process of applying for on Raku's behalf).

If no one objects, I plan to merge this PR before submitting the JetBrains application to avoid confusion.