### PR TITLE
Add test for enum's raku method

### DIFF
--- a/S12-enums/misc.t
+++ b/S12-enums/misc.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 27;
+plan 28;
 
 {
     class EnumClass     { enum C <a b c> }
@@ -136,6 +136,12 @@ plan 27;
 {
     enum BooleanEnum (:!Lies, :Truth);
     is-deeply True ~~ BooleanEnum, False, 'should not match';
+}
+
+# https://github.com/rakudo/rakudo/issues/5935
+{
+    my enum Directions <⬆️>;
+    lives-ok { Directions::<⬆️>.raku.EVAL }, 'enum raku method should be round-trippable';
 }
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
This test aims to ensure that calling the raku method on a enum member returns valid code when the enum member is an emoji.

See rakudo/rakudo#5935.