### PR TITLE
Roll enough times for the weighted roll tests to be stable

### DIFF
--- a/S02-types/bag.t
+++ b/S02-types/bag.t
@@ -268,14 +268,14 @@ sub showkv($x) {
     is +@a, 2, '.roll(2) returns the right number of items';
     is @a.grep(* eq 'a').elems + @a.grep(* eq 'b').elems, 2, '.roll(2) returned "a"s and "b"s';
 
-    @a = $b.roll: 100;
-    is +@a, 100, '.roll(100) returns 100 items';
-    ok 2 < @a.grep(* eq 'a') < 75, '.roll(100) (1)';
-    ok @a.grep(* eq 'a') + 2 < @a.grep(* eq 'b'), '.roll(100) (2)';
+    @a = $b.roll: 100000;
+    is +@a, 100000, '.roll(100000) returns 100000 items';
+    ok 2 < @a.grep(* eq 'a') < 75000, '.roll(100000) (1)';
+    ok @a.grep(* eq 'a') + 2 < @a.grep(* eq 'b'), '.roll(100000) (2)';
 
-    @a = $b.roll(*)[^100];
-    ok 2 < @a.grep(* eq 'a') < 75, '.roll(100) (1)';
-    ok @a.grep(* eq 'a') + 2 < @a.grep(* eq 'b'), '.roll(100) (2)';
+    @a = $b.roll(*)[^100000];
+    ok 2 < @a.grep(* eq 'a') < 75000, '.roll(100000) (1)';
+    ok @a.grep(* eq 'a') + 2 < @a.grep(* eq 'b'), '.roll(100000) (2)';
 
     is $b.total, 3, '.roll should not change Bag';
 }
@@ -286,10 +286,10 @@ sub showkv($x) {
     my $a = $b.roll;
     ok $a eq "a" || $a eq "b", "We got one of the two choices (and this was pretty quick, we hope!)";
 
-    my @a = $b.roll: 100;
-    is +@a, 100, '.roll(100) returns 100 items';
-    ok @a.grep(* eq 'a') > 97, '.roll(100) (1)';
-    ok @a.grep(* eq 'b') < 3, '.roll(100) (2)';
+    my @a = $b.roll: 100000;
+    is +@a, 100000, '.roll(100000) returns 100000 items';
+    ok @a.grep(* eq 'a') > 97000, '.roll(100000) (1)';
+    ok @a.grep(* eq 'b') < 3000, '.roll(100000) (2)';
     is $b.total, 100000000001, '.roll should not change Bag';
 }
 

--- a/S02-types/baghash.t
+++ b/S02-types/baghash.t
@@ -252,14 +252,14 @@ sub showkv($x) {
     is +@a, 2, '.roll(2) returns the right number of items';
     is @a.grep(* eq 'a').elems + @a.grep(* eq 'b').elems, 2, '.roll(2) returned "a"s and "b"s';
 
-    @a = $b.roll: 100;
-    is +@a, 100, '.roll(100) returns 100 items';
-    ok 2 < @a.grep(* eq 'a') < 75, '.roll(100) (1)';
-    ok @a.grep(* eq 'a') + 2 < @a.grep(* eq 'b'), '.roll(100) (2)';
+    @a = $b.roll: 100000;
+    is +@a, 100000, '.roll(100000) returns 100000 items';
+    ok 2 < @a.grep(* eq 'a') < 75000, '.roll(100000) (1)';
+    ok @a.grep(* eq 'a') + 2 < @a.grep(* eq 'b'), '.roll(100000) (2)';
 
-    @a = $b.roll(*)[^100];
-    ok 2 < @a.grep(* eq 'a') < 75, '.roll(100) (1)';
-    ok @a.grep(* eq 'a') + 2 < @a.grep(* eq 'b'), '.roll(100) (2)';
+    @a = $b.roll(*)[^100000];
+    ok 2 < @a.grep(* eq 'a') < 75000, '.roll(100000) (1)';
+    ok @a.grep(* eq 'a') + 2 < @a.grep(* eq 'b'), '.roll(100000) (2)';
 
     is $b.total, 3, '.roll should not change BagHash';
     is $b.elems, 2, '.roll should not change BagHash';
@@ -271,10 +271,10 @@ sub showkv($x) {
     my $a = $b.roll;
     ok $a eq "a" || $a eq "b", "We got one of the two choices (and this was pretty quick, we hope!)";
 
-    my @a = $b.roll: 100;
-    is +@a, 100, '.roll(100) returns 100 items';
-    ok @a.grep(* eq 'a') > 97, '.roll(100) (1)';
-    ok @a.grep(* eq 'b') < 3, '.roll(100) (2)';
+    my @a = $b.roll: 100000;
+    is +@a, 100000, '.roll(100000) returns 100000 items';
+    ok @a.grep(* eq 'a') > 97000, '.roll(100000) (1)';
+    ok @a.grep(* eq 'b') < 3000, '.roll(100000) (2)';
     is $b.total, 100000000001, '.roll should not change BagHash';
     is $b.elems, 2, '.roll should not change BagHash';
 }

--- a/S02-types/mixhash.t
+++ b/S02-types/mixhash.t
@@ -263,14 +263,14 @@ sub showkv($x) {
     is +@a, 2, '.roll(2) returns the right number of items';
     is @a.grep(* eq 'a').elems + @a.grep(* eq 'b').elems, 2, '.roll(2) returned "a"s and "b"s';
 
-    @a = $m.roll: 100;
-    is +@a, 100, '.roll(100) returns 100 items';
-    ok 2 < @a.grep(* eq 'a') < 75, '.roll(100) (1)';
-    ok @a.grep(* eq 'a') + 2 < @a.grep(* eq 'b'), '.roll(100) (2)';
+    @a = $m.roll: 100000;
+    is +@a, 100000, '.roll(100000) returns 100000 items';
+    ok 2 < @a.grep(* eq 'a') < 75000, '.roll(100000) (1)';
+    ok @a.grep(* eq 'a') + 2 < @a.grep(* eq 'b'), '.roll(100000) (2)';
 
-    @a = $m.roll(*)[^100];
-    ok 2 < @a.grep(* eq 'a') < 75, '.roll(*)[^100] (1)';
-    ok @a.grep(* eq 'a') + 2 < @a.grep(* eq 'b'), '.roll(*)[^100] (2)';
+    @a = $m.roll(*)[^100000];
+    ok 2 < @a.grep(* eq 'a') < 75000, '.roll(*)[^100000] (1)';
+    ok @a.grep(* eq 'a') + 2 < @a.grep(* eq 'b'), '.roll(*)[^100000] (2)';
 
     is $m.total, 3, '.roll should not change MixHash';
     is $m.elems, 2, '.roll should not change MixHash';
@@ -284,10 +284,10 @@ sub showkv($x) {
     my $a = $m.roll;
     ok $a eq "a" || $a eq "b", "We got one of the two choices (and this was pretty quick, we hope!)";
 
-    my @a = $m.roll: 100;
-    is +@a, 100, '.roll(100) returns 100 items';
-    ok @a.grep(* eq 'a') > 97, '.roll(100) (1)';
-    ok @a.grep(* eq 'b') < 3, '.roll(100) (2)';
+    my @a = $m.roll: 100000;
+    is +@a, 100000, '.roll(100000) returns 100000 items';
+    ok @a.grep(* eq 'a') > 97000, '.roll(100000) (1)';
+    ok @a.grep(* eq 'b') < 3000, '.roll(100000) (2)';
     is $m.total, 1, '.roll should not change MixHash';
     is $m.elems, 3, '.roll should not change MixHash';
 }


### PR DESCRIPTION
48466a57d did this for the Mix roll tests. The same assertions are in bag.t, baghash.t and mixhash.t, still drawing only 100 values. Rolling 100 times from a 1:2 bag and requiring the "a" count plus 2 to stay under the "b" count fails at 49 against an expectation of 33, which is roughly 1 in 1200 per assertion. There are six of them across the three files, so a spectest run tripped one every couple hundred runs.

This applies the same 100000 values and the same scaled bounds to the remaining files.