### PR TITLE
Await the independent .then before checking what it recorded

### DIFF
--- a/S17-promise/then.t
+++ b/S17-promise/then.t
@@ -75,6 +75,7 @@ subtest 'dynamics accessible from .then' => {
 {
     my %test-status;
     my $slock = Lock.new;
+    my $independent-then;
 
     my sub get-results($p1) {
         %test-status = ();
@@ -91,7 +92,9 @@ subtest 'dynamics accessible from .then' => {
             }
         }
 
-        $p1.then: { record-result($_, "independent-then"); };
+        # This one is not part of the chain returned below, so it has to be
+        # awaited separately before %test-status is read.
+        $independent-then = $p1.then: { record-result($_, "independent-then"); };
 
         $p1
             .andthen({ record-result($_, "andthen1"); .result < -10 ?? die "andthen1 dies" !! .result * 2 })
@@ -117,6 +120,7 @@ subtest 'dynamics accessible from .then' => {
                 my $p2 = get-results($p1);
 
                 is await($p2), $rc, "final promise result";
+                await $independent-then;
                 is-deeply %test-status, %status, "thens ran as expected";
             }
 
@@ -127,6 +131,7 @@ subtest 'dynamics accessible from .then' => {
                 $p1."$method"($value);
 
                 is await($p2), $rc, "final promise result";
+                await $independent-then;
                 is-deeply %test-status, %status, "thens ran as expected";
             }
         }


### PR DESCRIPTION
The conditional .then tests fire a .then on $p1 that records into %test-status and then throw away the Promise it returns. Only the andthen/orelse chain is awaited, so nothing guarantees that recording has happened by the time is-deeply reads the hash. When it has not, the comparison sees a %test-status that is still missing a key and fails, and the missing entry lands before the failure diag renders, so the reported expected and got are identical and the failure looks impossible. Reproduced at roughly 3 in 10000 on an idle machine, and the CI agents are neither idle nor fast.

is-deeply also reads %test-status without taking $slock while those callbacks are still writing to it, which is a data race in its own right. Awaiting the promise leaves no writer running by the time the hash is read, so both problems go away.

This keeps the Promise and awaits it before each check.