### PR TITLE
Wait for the Channel Supply to drain before checking what it saw

### DIFF
--- a/S17-channel/basic.t
+++ b/S17-channel/basic.t
@@ -109,12 +109,15 @@ plan 29;
 # https://github.com/rakudo/rakudo/issues/1974
 {
     my @seen;
-    (my Channel $c .= new).Supply.tap: { @seen.push($_) };
+    my $drained = Promise.new;
+    (my Channel $c .= new).Supply.tap: { @seen.push($_) },
+        done => { $drained.keep };
     sub get-urls($url) {
         gather { take $url; $url.chars > 1 and (.take for get-urls $url.chop) }
     }
     await get-urls("meows").Supply.throttle: 3, {$c.send: $_};
     $c.close;
+    await $drained;
     is-deeply @seen, [<meows meow meo me m>], 'got all urls';
 }
 


### PR DESCRIPTION
Previously the test closed the channel and immediately checked @seen, but Channel.Supply delivers values to its tap on a thread pool thread. Nothing synchronized the check with that delivery, so under load the main thread could read @seen before the tap finished pushing the last values. This taps with a done callback and awaits its promise after closing the channel, which Channel.Supply keeps only once the channel is drained.