### PR TITLE
Make the EADDRINUSE quit test deterministic

### DIFF
--- a/S32-io/IO-Socket-Async.t
+++ b/S32-io/IO-Socket-Async.t
@@ -250,14 +250,17 @@ $echoTap.close;
 }
 
 {
-    # random (hopefully invalid) port on localhost
-    my $random-port = (5_000..10_000).pick;
-    my $badServer = IO::Socket::Async.listen($s-address, $random-port);
+    # hold a port so a second listen on it is guaranteed to fail
+    my $holderTap = IO::Socket::Async.listen($s-address, 0).tap();
+    my $held-port = await $holderTap.socket-port;
+    my $badServer = IO::Socket::Async.listen($s-address, $held-port);
     my $failed = Promise.new;
-    my $t1 = $badServer.tap();
-    my $t2 = $badServer.tap(quit => { $failed.keep });
+    # neither tap gets closed: closing the failed one hangs awaiting a
+    # socket that will never arrive, and closing the holder after a
+    # failed listen panics MoarVM on the next listen tap cancellation
+    $badServer.tap(quit => { $failed.keep });
     await Promise.anyof($failed, Promise.in(5));
-    ok $failed, 'Address already in use results in a quit';
+    is $failed.status, Kept, 'Address already in use results in a quit';
 }
 
 {


### PR DESCRIPTION
Previously this test picked a random port between 5000 and 10000 and tapped the same listen supply twice, expecting the first tap to win the bind and the second to quit. When something on the machine already held that port both listens failed. The first tap had no quit handler, and a failed listen also panics MoarVM on the next listen tap cancellation, which killed the test file after test 26. This binds a holder listener on port 0 first so the port is guaranteed to be in use, taps a single listener on that port with a quit handler, and checks the promise status rather than the always-truthy promise object.