### PR TITLE
Run a silent child in the RT #115390 loops

### DIFF
--- a/S29-os/system.t
+++ b/S29-os/system.t
@@ -62,14 +62,14 @@ throws-like { shell("program_that_does_not_exist_ignore_errors_please.exe") },
     my $rt115390;
     for 1..100 -> $i {
         $rt115390 += $i.raku;
-        run "$*EXECUTABLE", "-v";
+        run "$*EXECUTABLE", "-e", "";
         1;
     }
     is $rt115390, 5050, 'no crash with run() in loop; run() in sink context';
     $rt115390 = 0;
     for 1..100 -> $i {
         $rt115390 += $i.raku;
-        my $var = run "$*EXECUTABLE", "-v";
+        my $var = run "$*EXECUTABLE", "-e", "";
         1;
     }
     is $rt115390, 5050, 'no crash with run() in loop; run() not in sink context';


### PR DESCRIPTION
The 200 iterations ran raku -v with inherited standard output, so every child wrote a three line version banner into the harness stream. Under CI load a banner chunk can land inside a test line, which corrupts the numbering and fails the file with tests out of sequence. An empty -e program spawns the same way and prints nothing. The loops only pin that run() in a loop does not crash, in sink context and assigned, so the command output was never part of the test.