### PR TITLE
Reach the run time type check with a value the compiler cannot judge

### DIFF
--- a/6.c/S04-declarations/my-6c.t
+++ b/6.c/S04-declarations/my-6c.t
@@ -235,23 +235,27 @@ throws-like 'my $z = $z', X::Syntax::Variable::Initializer, name => '$z';
     # If there is a regression this may die not just fail to make ints
     eval-lives-ok 'my (int $a);','native in declarator sig';
     eval-lives-ok 'my (int $a, int $b);','natives in declarator sig';
-    dies-ok { my (int $a, num $b); $a = 'omg'; }, 'Native types in declarator sig 1/2 constrains';
-    dies-ok { my (int $a, num $b); $b = 'omg'; }, 'Native types in declarator sig 2/2 constrains';
+    # The value assigned is held in a variable so that the declared type is what
+    # rejects it, rather than the compiler rejecting the literal out of hand.
+    my $omg = 'omg';
+    my $str = "str";
+    dies-ok { my (int $a, num $b); $a = $omg; }, 'Native types in declarator sig 1/2 constrains';
+    dies-ok { my (int $a, num $b); $b = $omg; }, 'Native types in declarator sig 2/2 constrains';
     lives-ok { my (int $a, num $b); $a = 42; $b = 4e2; }, 'Native types in declarator sig allow correct assignments';
 
-    throws-like { my (Int $a); $a = "str" }, X::TypeCheck, 'Type in declarator sig 1/1 constrains';
-    throws-like { my (Int $a, Num $b); $a = "str" }, X::TypeCheck, 'Types in declarator sig 1/2 constrain';
-    throws-like { my (Int $a, Num $b); $b = "str" }, X::TypeCheck, 'Types in declarator sig 2/2 constrain';
+    throws-like { my (Int $a); $a = $str }, X::TypeCheck, 'Type in declarator sig 1/1 constrains';
+    throws-like { my (Int $a, Num $b); $a = $str }, X::TypeCheck, 'Types in declarator sig 1/2 constrain';
+    throws-like { my (Int $a, Num $b); $b = $str }, X::TypeCheck, 'Types in declarator sig 2/2 constrain';
     lives-ok { my (Int $a, Num $b); $a = 1; $b = 1e0; }, 'Types in declarator sig allow correct assignments';
 
     # These still need spec clarification but test them, since they pass
     eval-lives-ok 'my int ($a);', 'native outside declarator sig 1';
     eval-lives-ok 'my int ($a, $b)', 'native outside declarator sig 2';
-    throws-like { my Int ($a); $a = "str" }, X::TypeCheck, 'Type outside declarator sig 1/1 constrains';
-    throws-like { my Int ($a, $b); $a = "str" }, X::TypeCheck, 'Type outside declarator sig 1/2 constrains';
-    throws-like { my Int ($a, $b); $b = "str"}, X::TypeCheck, 'Type outside declarator sig 2/2 constrains';
-    dies-ok { my int ($a, $b); $a = "str" }, 'Native type outside declarator sig 1/2 constrains';
-    dies-ok { my int ($a, $b); $b = "str" }, 'Native type outside declarator sig 2/2 constrains';
+    throws-like { my Int ($a); $a = $str }, X::TypeCheck, 'Type outside declarator sig 1/1 constrains';
+    throws-like { my Int ($a, $b); $a = $str }, X::TypeCheck, 'Type outside declarator sig 1/2 constrains';
+    throws-like { my Int ($a, $b); $b = $str}, X::TypeCheck, 'Type outside declarator sig 2/2 constrains';
+    dies-ok { my int ($a, $b); $a = $str }, 'Native type outside declarator sig 1/2 constrains';
+    dies-ok { my int ($a, $b); $b = $str }, 'Native type outside declarator sig 2/2 constrains';
 }
 
 # https://github.com/Raku/old-issue-tracker/issues/2983

--- a/6.c/S04-declarations/my-6c.t
+++ b/6.c/S04-declarations/my-6c.t
@@ -237,10 +237,9 @@ throws-like 'my $z = $z', X::Syntax::Variable::Initializer, name => '$z';
     eval-lives-ok 'my (int $a, int $b);','natives in declarator sig';
     # The value assigned is held in a variable so that the declared type is what
     # rejects it, rather than the compiler rejecting the literal out of hand.
-    my $omg = 'omg';
     my $str = "str";
-    dies-ok { my (int $a, num $b); $a = $omg; }, 'Native types in declarator sig 1/2 constrains';
-    dies-ok { my (int $a, num $b); $b = $omg; }, 'Native types in declarator sig 2/2 constrains';
+    dies-ok { my (int $a, num $b); $a = $str; }, 'Native types in declarator sig 1/2 constrains';
+    dies-ok { my (int $a, num $b); $b = $str; }, 'Native types in declarator sig 2/2 constrains';
     lives-ok { my (int $a, num $b); $a = 42; $b = 4e2; }, 'Native types in declarator sig allow correct assignments';
 
     throws-like { my (Int $a); $a = $str }, X::TypeCheck, 'Type in declarator sig 1/1 constrains';

--- a/S04-declarations/my-6e.t
+++ b/S04-declarations/my-6e.t
@@ -234,23 +234,27 @@ throws-like 'my $z = $z', X::Syntax::Variable::Initializer, name => '$z';
     # If there is a regression this may die not just fail to make ints
     eval-lives-ok 'my (int $a);','native in declarator sig';
     eval-lives-ok 'my (int $a, int $b);','natives in declarator sig';
-    dies-ok { my (int $a, num $b); $a = 'omg'; }, 'Native types in declarator sig 1/2 constrains';
-    dies-ok { my (int $a, num $b); $b = 'omg'; }, 'Native types in declarator sig 2/2 constrains';
+    # The value assigned is held in a variable so that the declared type is what
+    # rejects it, rather than the compiler rejecting the literal out of hand.
+    my $omg = 'omg';
+    my $str = "str";
+    dies-ok { my (int $a, num $b); $a = $omg; }, 'Native types in declarator sig 1/2 constrains';
+    dies-ok { my (int $a, num $b); $b = $omg; }, 'Native types in declarator sig 2/2 constrains';
     lives-ok { my (int $a, num $b); $a = 42; $b = 4e2; }, 'Native types in declarator sig allow correct assignments';
 
-    throws-like { my (Int $a); $a = "str" }, X::TypeCheck, 'Type in declarator sig 1/1 constrains';
-    throws-like { my (Int $a, Num $b); $a = "str" }, X::TypeCheck, 'Types in declarator sig 1/2 constrain';
-    throws-like { my (Int $a, Num $b); $b = "str" }, X::TypeCheck, 'Types in declarator sig 2/2 constrain';
+    throws-like { my (Int $a); $a = $str }, X::TypeCheck, 'Type in declarator sig 1/1 constrains';
+    throws-like { my (Int $a, Num $b); $a = $str }, X::TypeCheck, 'Types in declarator sig 1/2 constrain';
+    throws-like { my (Int $a, Num $b); $b = $str }, X::TypeCheck, 'Types in declarator sig 2/2 constrain';
     lives-ok { my (Int $a, Num $b); $a = 1; $b = 1e0; }, 'Types in declarator sig allow correct assignments';
 
     # These still need spec clarification but test them, since they pass
     eval-lives-ok 'my int ($a);', 'native outside declarator sig 1';
     eval-lives-ok 'my int ($a, $b)', 'native outside declarator sig 2';
-    throws-like { my Int ($a); $a = "str" }, X::TypeCheck, 'Type outside declarator sig 1/1 constrains';
-    throws-like { my Int ($a, $b); $a = "str" }, X::TypeCheck, 'Type outside declarator sig 1/2 constrains';
-    throws-like { my Int ($a, $b); $b = "str"}, X::TypeCheck, 'Type outside declarator sig 2/2 constrains';
-    dies-ok { my int ($a, $b); $a = "str" }, 'Native type outside declarator sig 1/2 constrains';
-    dies-ok { my int ($a, $b); $b = "str" }, 'Native type outside declarator sig 2/2 constrains';
+    throws-like { my Int ($a); $a = $str }, X::TypeCheck, 'Type outside declarator sig 1/1 constrains';
+    throws-like { my Int ($a, $b); $a = $str }, X::TypeCheck, 'Type outside declarator sig 1/2 constrains';
+    throws-like { my Int ($a, $b); $b = $str}, X::TypeCheck, 'Type outside declarator sig 2/2 constrains';
+    dies-ok { my int ($a, $b); $a = $str }, 'Native type outside declarator sig 1/2 constrains';
+    dies-ok { my int ($a, $b); $b = $str }, 'Native type outside declarator sig 2/2 constrains';
 }
 
 # https://github.com/Raku/old-issue-tracker/issues/2983

--- a/S04-declarations/my-6e.t
+++ b/S04-declarations/my-6e.t
@@ -236,10 +236,9 @@ throws-like 'my $z = $z', X::Syntax::Variable::Initializer, name => '$z';
     eval-lives-ok 'my (int $a, int $b);','natives in declarator sig';
     # The value assigned is held in a variable so that the declared type is what
     # rejects it, rather than the compiler rejecting the literal out of hand.
-    my $omg = 'omg';
     my $str = "str";
-    dies-ok { my (int $a, num $b); $a = $omg; }, 'Native types in declarator sig 1/2 constrains';
-    dies-ok { my (int $a, num $b); $b = $omg; }, 'Native types in declarator sig 2/2 constrains';
+    dies-ok { my (int $a, num $b); $a = $str; }, 'Native types in declarator sig 1/2 constrains';
+    dies-ok { my (int $a, num $b); $b = $str; }, 'Native types in declarator sig 2/2 constrains';
     lives-ok { my (int $a, num $b); $a = 42; $b = 4e2; }, 'Native types in declarator sig allow correct assignments';
 
     throws-like { my (Int $a); $a = $str }, X::TypeCheck, 'Type in declarator sig 1/1 constrains';

--- a/S09-typed-arrays/arrays.t
+++ b/S09-typed-arrays/arrays.t
@@ -54,8 +54,12 @@ plan 84;
 
 {
     my Array @x;
+    # The values assigned are held in a variable so that the element type is
+    # what rejects them, rather than the compiler rejecting the literals out
+    # of hand.
+    my @wrong = 1, 2, 3;
     ok @x.VAR.of === Array, '@x.VAR.of of typed array (my Array @x)';
-    dies-ok { @x = 1, 2, 3 }, 'can not assign values of the wrong type';
+    dies-ok { @x = @wrong }, 'can not assign values of the wrong type';
     dies-ok { @x = 1..3    }, 'can not assign range of the wrong type';
     dies-ok { @x.push: 3, 4}, 'can not push values of the wrong type';
     dies-ok { @x.unshift: 3}, 'can not unshift values of the wrong type';
@@ -67,8 +71,9 @@ plan 84;
 
 {
     my @x of Array;
+    my @wrong = 1, 2, 3;
     ok @x.VAR.of === Array, '@x.VAR.of of typed array (my @x of Array)';
-    dies-ok { @x = 1, 2, 3 }, 'can not assign values of the wrong type';
+    dies-ok { @x = @wrong }, 'can not assign values of the wrong type';
     dies-ok { @x = 1..3    }, 'can not assign range of the wrong type';
     dies-ok { @x.push: 3, 4}, 'can not push values of the wrong type';
     dies-ok { @x.unshift: 3}, 'can not unshift values of the wrong type';
@@ -112,8 +117,8 @@ plan 84;
     sub ret_pos_2 returns Positional of Int { my Int @a = 1,2,3; @a }
     sub ret_pos_3 returns Positional of Int { my @a = 1,2,3; return @a; }
     sub ret_pos_4 returns Positional of Int { my @a = 1,2,3; @a }
-    sub ret_pos_5 returns Positional of Int { my Num @a = 1,2,3; return @a; }
-    sub ret_pos_6 returns Positional of Int { my Num @a = 1,2,3; @a }
+    sub ret_pos_5 returns Positional of Int { my Num @a = 1e0,2e0,3e0; return @a; }
+    sub ret_pos_6 returns Positional of Int { my Num @a = 1e0,2e0,3e0; @a }
     sub ret_pos_7 returns Positional of Numeric { my Int @a = 1,2,3; return @a; }
     sub ret_pos_8 returns Positional of Numeric { my Int @a = 1,2,3; @a }
     lives-ok { ret_pos_1() },

--- a/S12-enums/basic.t
+++ b/S12-enums/basic.t
@@ -83,7 +83,10 @@ eval-lives-ok 'my enum Empty2 ()', 'empty enum with () can be constructed';
     ok($c1 == 0, 'can assign enum value to typed variable with long name');
     my Color $c2 = white;
     ok($c2 == 0, 'can assign enum value to typed variable with short name');
-    dies-ok({ my Color $c3 = "for the fail" },
+    # The value assigned is held in a variable so that the enum is what rejects
+    # it, rather than the compiler rejecting the literal out of hand.
+    my $fail = "for the fail";
+    dies-ok({ my Color $c3 = $fail },
         'enum as a type enforces checks');
 
     # conflict between subs and enums


### PR DESCRIPTION
Rakudo is learning to report a store of a value a variable's type can never accept while it compiles, instead of leaving it to the run time check. A test written as `dies-ok { my Int $x = "str" }` names a literal the compiler can judge, so it stops reaching the check it was written for.

Each of these holds the value in a variable instead. The store still happens, the type still rejects it, and the check under test is the one that runs. The two subs returning a typed positional get values written as the type their array declares, so what fails is the return constraint they are testing rather than the declaration above it.