### PR TITLE
Test escapes and combining characters in character classes

### DIFF
--- a/S05-modifier/ignorecase.t
+++ b/S05-modifier/ignorecase.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 101;
+plan 115;
 
 =begin description
 
@@ -81,6 +81,21 @@ ok 'A4' ~~ /:i a[3|4|5] | b[3|4] /, 'alternation sanity';
     ok  "m" ~~ /:i <[M]>/, "ignore case of character classes";
     nok "m" ~~ /<[M]>/,    "ignore case of character classes";
     nok "n" ~~ /:i <[M]>/, "ignore case of character classes";
+    # https://github.com/rakudo/rakudo/issues/2962
+    ok  "m" ~~ /:i <[ \x[4D] ]>/, "ignore case of a hex escape in a character class";
+    ok  "m" ~~ /:i <[ \c[LATIN CAPITAL LETTER M] ]>/, "ignore case of a named escape in a character class";
+    ok  "ß" ~~ /:i <[ \x[DF] ]>/, "escape that folds to two characters still matches itself in a character class";
+    nok "s" ~~ /:i <[ \x[DF] ]>/, "escape that folds to two characters does not match part of the fold";
+    ok  "ß" ~~ /:i <[ ß ]>/, "character that folds to two characters still matches itself in a character class";
+    nok "s" ~~ /:i <[ ß ]>/, "character that folds to two characters does not match part of the fold";
+    ok  "\x[300]" ~~ /:i <[ \x[300] ]>/, "lone combining escape in a character class matches itself under ignorecase";
+    nok "f" ~~ /:i <[ \c[LATIN SMALL LIGATURE FF] ]>/, "ligature escape in a character class does not match part of the fold";
+    ok  "ﬀ" ~~ /:i <[ ﬀ ]>/, "ligature in a character class still matches itself";
+    nok "m" ~~ /:i <-[ \x[4D] ]>/, "negated character class with a hex escape rejects the other case";
+    ok  "n" ~~ /:i <-[ \x[4D] ]>/, "negated character class with a hex escape accepts other characters";
+    ok  "ǅ" ~~ /:i <[ ǆ ]>/, "character class matches the titlecase form of its entry";
+    ok  "ä" ~~ /:i <[ a \x[308] ]>/, "character class entry formed by a base character and combining escape matches itself";
+    nok "a" ~~ /:i <[ a \x[308] ]>/, "character class entry formed by a base character and combining escape does not match the bare base character";
 }
 
 # https://github.com/Raku/old-issue-tracker/issues/4811

--- a/S05-modifier/ignoremark.t
+++ b/S05-modifier/ignoremark.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 45;
+plan 60;
 
 =begin description
 
@@ -84,6 +84,25 @@ is "\c[SYRIAC ABBREVIATION MARK, COMBINING CARON]" ~~ /:m "\c[SYRIAC ABBREVIATIO
 # https://github.com/rakudo/rakudo/issues/2961
 {
     is "a\x[300]" ~~ / :ignoremark <[ a b c ]> /, 'à', 'charclass ok';
+}
+
+# https://github.com/rakudo/rakudo/issues/2962
+{
+    is "a\x[300]" ~~ / :ignoremark <[ a \n ]> /, 'à', 'charclass with a newline escape matches a marked character';
+    is "a\x[300]" ~~ / :ignoremark <[ a \r\n ]> /, 'à', 'charclass with carriage return and newline escapes matches a marked character';
+    is "a\x[300]" ~~ / :ignoremark [ \n | <[ a ]> ] /, 'à', 'charclass after an alternation branch matches a marked character';
+    is "a\x[300]" ~~ / :ignoremark [ <[ a ]> | \n ] /, 'à', 'charclass before an alternation branch matches a marked character';
+    nok "x" ~~ / :ignoremark <[ a \n ]> /, 'charclass with a newline escape still rejects other characters';
+    is "a" ~~ / :ignoremark <[ \x[E0] ]> /, 'a', 'hex escape in a charclass ignores its mark';
+    is "a\x[300]" ~~ / :ignoremark <[ a \x[300] ]> /, 'à', 'charclass entry formed by a base character and combining escape matches a marked character';
+    is "a\x[300]" ~~ / :ignoremark [ \n | <[ b a ]> ] /, 'à', 'charclass in an alternation matches on its second entry';
+    nok "a\x[300]" ~~ / :ignoremark <-[ a \x[300] ]> /, 'negated charclass entry formed by a base character and combining escape rejects a marked character';
+    is "b\x[300]" ~~ / :ignoremark <-[ a \x[300] ]> /, "b\x[300]", 'negated charclass entry formed by a base character and combining escape accepts another marked character';
+    is "A\x[300]" ~~ / :i:m <[ \x[61] ]> /, 'À', 'hex escape in a charclass ignores case and mark together';
+    is "a" ~~ / :i:m <[ \x[C0] ]> /, 'a', 'hex escape with a mark in a charclass matches the bare base character under ignorecase and ignoremark';
+    is "b\x[300]" ~~ / :ignoremark [ \n | <-[ a ]> ] /, "b\x[300]", 'negated charclass in an alternation accepts another marked character';
+    is "\n" ~~ / :ignoremark <[ \x[D]\x[A] \x[A] ]> /, "\n", 'folded entries that would form one grapheme stay separate entries';
+    is "\r" ~~ / :ignoremark <[ \x[D]\x[A] \x[A] ]> /, "\r", 'a folded carriage return newline entry matches a carriage return';
 }
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
Covers ignoremark character classes that sit in an alternation, hex and named escapes under :ignorecase and :ignoremark, case forms that are not a single character, and a base character followed by a combining escape forming one entry of the class.

Requires https://github.com/Raku/nqp/pull/870 and https://github.com/rakudo/rakudo/pull/6641

rakudo/rakudo#2962